### PR TITLE
AUT-3365 - Deploy Cloudfront distribution for build account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+authentication-frontend

--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@
 Configure AWS SSO as described in [Setting Up SSO Profiles (Confluence)](https://govukverify.atlassian.net/wiki/spaces/LO/pages/3831890210/How+to+deploy+to+sandpit+authdev+environments#Setting-up-SSO-profiles)
 
 Run `./provision-<environment>.sh` to bootstrap an account. You may be prompted to authenticate with AWS Identity Center before continuing.
+
+Run `./provision-cloudfront-<environment>.sh` to deploy CloudFront distribution and additional dependencies described in the [CloudFront header](https://govukverify.atlassian.net/wiki/spaces/DID/pages/4026401532/Part+1+-+Deploying+CloudFront) trust initiative.
+
+### Helper scripts
+
+[sync-dependencies.sh](./sync-dependencies.sh) - deploys and maintains a shallow copy of authentication-frontend repository, in order to source several cloudformation templates used in the provision scripts
+
+[read_secrets.sh](./scripts/read_secrets.sh) - extracts all secrets stored in AWS Secrets Manager named as `/deploy/\${Environment}/secret-name` and export to shell as `secret-name=value`
+
+[read_parameters.sh](./scripts/read_parameters.sh) - extracts all parameters stored in AWS Systems Manager Parameter store named as `/deploy/\${Environment}/param-name` and export to shell as `param-name=value`
+
+Both secrets and parameters are then injected to the provisioner script

--- a/configuration/di-authentication-build/auth-fe-cloudfront-certificate/parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront-certificate/parameters.json
@@ -1,0 +1,6 @@
+[
+    {
+      "ParameterKey": "DomainName",
+      "ParameterValue": "signin-sp.build.account.gov.uk"
+    }
+  ]

--- a/configuration/di-authentication-build/auth-fe-cloudfront-certificate/parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront-certificate/parameters.json
@@ -1,6 +1,6 @@
 [
-    {
-      "ParameterKey": "DomainName",
-      "ParameterValue": "signin-sp.build.account.gov.uk"
-    }
-  ]
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "signin-sp.build.account.gov.uk"
+  }
+]

--- a/configuration/di-authentication-build/auth-fe-cloudfront-monitoring/parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront-monitoring/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "CloudFrontAdditionaldMetricsEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "CacheHitAlarmSNSTopicARN",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  }
+]

--- a/configuration/di-authentication-build/auth-fe-cloudfront-waf/parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront-waf/parameters.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  }
+]

--- a/configuration/di-authentication-build/auth-fe-cloudfront/parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront/parameters.json
@@ -4,10 +4,6 @@
     "ParameterValue": "false"
   },
   {
-    "ParameterKey": "CloudFrontWafACL",
-    "ParameterValue": "none"
-  },
-  {
     "ParameterKey": "DistributionAlias",
     "ParameterValue": "signin-sp.build.account.gov.uk"
   },

--- a/configuration/di-authentication-build/auth-fe-cloudfront/parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront/parameters.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ParameterKey": "AddWWWPrefix",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "CloudFrontWafACL",
+    "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "signin-sp.build.account.gov.uk"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "none"
+  }
+]

--- a/configuration/di-authentication-build/dns-zones-and-records/parameters.json
+++ b/configuration/di-authentication-build/dns-zones-and-records/parameters.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  }
+]

--- a/provision-build.sh
+++ b/provision-build.sh
@@ -33,3 +33,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
 ./provisioner.sh "${AWS_ACCOUNT}" service-down-page-image-repository container-image-repository v1.3.2
 
 ./provisioner.sh "${AWS_ACCOUNT}" frontend-pipeline sam-deploy-pipeline v2.60.2
+
+TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" dns-zones-and-records dns LATEST

--- a/provision-build.sh
+++ b/provision-build.sh
@@ -34,4 +34,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
 
 ./provisioner.sh "${AWS_ACCOUNT}" frontend-pipeline sam-deploy-pipeline v2.60.2
 
+# shallow clone templates from authentication repos
+./sync-dependencies.sh
+
 TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" dns-zones-and-records dns LATEST

--- a/provision-build.sh
+++ b/provision-build.sh
@@ -24,8 +24,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
 # ./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.1
 # ./provisioner.sh "${AWS_ACCOUNT}" certificate-expiry certificate-expiry v1.1.1
 # ./provisioner.sh "${AWS_ACCOUNT}" checkov-hook checkov-hook LATEST
-# ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
-# ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
+./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
+./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
 ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc v2.5.2
 
 ./provisioner.sh "${AWS_ACCOUNT}" frontend-image-repository container-image-repository v1.3.2

--- a/provision-cloudfront-build.sh
+++ b/provision-cloudfront-build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure we are in the directory of the script
+cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
+
+export AWS_ACCOUNT=di-authentication-build
+export AWS_PROFILE=di-authentication-build-AWSAdministratorAccess
+aws sso login --profile "${AWS_PROFILE}"
+
+source "scripts/read_secrets.sh" "build"
+source "scripts/read_parameters.sh" "build"
+
+# cloudfront certificate generation, no dependency
+PARAMETERS_FILE="configuration/$AWS_ACCOUNT/auth-fe-cloudfront-certificate/parameters.json"
+HostedZoneID=${signin_route53_hostedzone_id:-""}
+PARAMETERS=$(jq ". += [{\"ParameterKey\":\"HostedZoneID\",\"ParameterValue\":\"${HostedZoneID}\"}] | tojson" -r "${PARAMETERS_FILE}")
+TMP_PARAM_FILE=$(mktemp)
+echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
+
+aws configure set region us-east-1
+PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" auth-fe-cloudfront-certificate certificate v1.1.1
+
+# Feed output to the next stack
+CertificateARN=$(aws cloudformation describe-stacks \
+    --stack-name auth-fe-cloudfront-certificate --region us-east-1  |
+    jq -r '.Stacks[0].Outputs[] | select(.OutputKey | match("CertificateARN")) | .OutputValue')
+
+# cloudfront distribution, dependent on auth-fe-cloudfront-certificate
+PARAMETERS_FILE="configuration/$AWS_ACCOUNT/auth-fe-cloudfront/parameters.json"
+OriginCloakingHeader=${signin_origin_cloaking_header:-""}
+PreviousOriginCloakingHeader=${previous_signin_origin_cloaking_header:-""}
+PARAMETERS=$(jq ". += [{\"ParameterKey\":\"CloudFrontCertArn\",\"ParameterValue\":\"${CertificateARN}\"},{\"ParameterKey\":\"OriginCloakingHeader\",\"ParameterValue\":\"${OriginCloakingHeader}\"},{\"ParameterKey\":\"PreviousOriginCloakingHeader\",\"ParameterValue\":\"${PreviousOriginCloakingHeader}\"}] | tojson" -r "${PARAMETERS_FILE}")
+TMP_PARAM_FILE=$(mktemp)
+echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
+
+aws configure set region eu-west-2
+PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" auth-fe-cloudfront cloudfront-distribution v1.3.1
+
+# # cloudfront monitoring, dependent on auth-fe-cloudfront
+# aws configure set region us-east-1
+
+
+# # reset
+# aws configure set region eu-west-2

--- a/provision-cloudfront-build.sh
+++ b/provision-cloudfront-build.sh
@@ -8,10 +8,17 @@ export AWS_ACCOUNT=di-authentication-build
 export AWS_PROFILE=di-authentication-build-AWSAdministratorAccess
 aws sso login --profile "${AWS_PROFILE}"
 
-source "scripts/read_secrets.sh" "build"
-source "scripts/read_parameters.sh" "build"
+# shellcheck source=/dev/null
+source "./scripts/read_secrets.sh" "build"
 
-# cloudfront certificate generation, no dependency
+# shellcheck source=/dev/null
+source "./scripts/read_parameters.sh" "build"
+
+# ----------------------------------------------------------
+# auth-fe-cloudfront-certificate
+#   Provision an ACM certificate for CloudFront distribution
+#   no dependency
+# ----------------------------------------------------------
 PARAMETERS_FILE="configuration/$AWS_ACCOUNT/auth-fe-cloudfront-certificate/parameters.json"
 HostedZoneID=${signin_route53_hostedzone_id:-""}
 PARAMETERS=$(jq ". += [{\"ParameterKey\":\"HostedZoneID\",\"ParameterValue\":\"${HostedZoneID}\"}] | tojson" -r "${PARAMETERS_FILE}")
@@ -26,7 +33,11 @@ CertificateARN=$(aws cloudformation describe-stacks \
     --stack-name auth-fe-cloudfront-certificate --region us-east-1  |
     jq -r '.Stacks[0].Outputs[] | select(.OutputKey | match("CertificateARN")) | .OutputValue')
 
-# cloudfront distribution, dependent on auth-fe-cloudfront-certificate
+# ------------------------------------------------------------------------------
+# auth-fe-cloudfront
+#   Creates the CloudFront distribution
+#   depends on: auth-fe-cloudfront-certificate
+# ------------------------------------------------------------------------------
 PARAMETERS_FILE="configuration/$AWS_ACCOUNT/auth-fe-cloudfront/parameters.json"
 OriginCloakingHeader=${signin_origin_cloaking_header:-""}
 PreviousOriginCloakingHeader=${previous_signin_origin_cloaking_header:-""}
@@ -35,11 +46,26 @@ TMP_PARAM_FILE=$(mktemp)
 echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
 
 aws configure set region eu-west-2
-PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" auth-fe-cloudfront cloudfront-distribution v1.3.1
+PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" auth-fe-cloudfront cloudfront-distribution v1.6.0
 
-# # cloudfront monitoring, dependent on auth-fe-cloudfront
-# aws configure set region us-east-1
+CloudFrontDistributionID=$(aws cloudformation describe-stacks \
+    --stack-name auth-fe-cloudfront --region eu-west-2 |
+    jq -r '.Stacks[0].Outputs[] | select(.OutputKey | match("DistributionId")) | .OutputValue')
 
+# ------------------------------------------------------
+# auth-fe-cloudfront-monitoring
+#   deploys CloudFront Extended Monitoring configuration
+#   depends on: auth-fe-cloudfront
+# ------------------------------------------------------
+PARAMETERS_FILE="configuration/$AWS_ACCOUNT/auth-fe-cloudfront-monitoring/parameters.json"
+PARAMETERS=$(jq ". += [{\"ParameterKey\":\"CloudfrontDistribution\",\"ParameterValue\":\"${CloudFrontDistributionID}\"}] | tojson" -r "${PARAMETERS_FILE}")
+TMP_PARAM_FILE=$(mktemp)
+echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
 
-# # reset
-# aws configure set region eu-west-2
+aws configure set region us-east-1
+PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" auth-fe-cloudfront-monitoring cloudfront-monitoring-alarm v2.0.0
+
+# -----
+# reset
+# -----
+aws configure set region eu-west-2

--- a/provisioner.sh
+++ b/provisioner.sh
@@ -80,12 +80,19 @@ function create_stack {
   local template_url="$2"
   local parameters_file="$3"
   local tags_file="$4"
+  local cmd_option=""
+
+  if [[ $template_url =~ "file://" ]]; then
+    cmd_option="--template-body"
+  else
+    cmd_option="--template-url"
+  fi
 
   echo "Creating new stack ${stack_name}"
   aws cloudformation create-stack \
     --stack-name="${stack_name}" \
     --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-    --template-url "${template_url}" \
+    ${cmd_option} "${template_url}" \
     --parameters="$(jq '. | tojson' -r "${parameters_file}")" \
     --tags="$(jq '. | tojson' -r "${tags_file}")"
 
@@ -103,13 +110,20 @@ function create_change_set {
   local template_url="$3"
   local parameters_file="$4"
   local tags_file="$5"
+  local cmd_option=""
+
+  if [[ $template_url =~ "file://" ]]; then
+    cmd_option="--template-body"
+  else
+    cmd_option="--template-url"
+  fi
 
   echo "Creating ${change_set_name} change set"
   aws cloudformation create-change-set \
     --stack-name="${stack_name}" \
     --change-set-name="${change_set_name}" \
     --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-    --template-url "${template_url}" \
+    ${cmd_option} "${template_url}" \
     --parameters="$(jq '. | tojson' -r "${parameters_file}")" \
     --tags="$(jq '. | tojson' -r "${tags_file}")"
 
@@ -214,7 +228,7 @@ function main {
 
   # Defaults
   TEMPLATE_BUCKET="${TEMPLATE_BUCKET:=template-storage-templatebucket-1upzyw6v9cs42}"
-  TEMPLATE_URL="https://${TEMPLATE_BUCKET}.s3.amazonaws.com/${STACK_TEMPLATE}/template.yaml"
+  TEMPLATE_URL="${TEMPLATE_URL:=https://${TEMPLATE_BUCKET}.s3.amazonaws.com/${STACK_TEMPLATE}/template.yaml}"
   PARAMETERS_FILE="${PARAMETERS_FILE:=./configuration/${AWS_ACCOUNT}/${STACK_NAME}/parameters.json}"
   TAGS_FILE="${TAGS_FILE:=./configuration/${AWS_ACCOUNT}/tags.json}"
 

--- a/scripts/read_parameters.sh
+++ b/scripts/read_parameters.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
+ENVIRONMENT="${1}"
+configured_region="$(aws configure get region 2>/dev/null || true)"
+REGION="${configured_region:-eu-west-2}"
+
+if [ "$ENVIRONMENT" = "dev" ]; then
+  ENVIRONMENT="build"
+fi
+
+parameters="$(
+  aws ssm get-parameters-by-path \
+    --recursive --path "/deploy/${ENVIRONMENT}" --region "${REGION}" |
+    jq -r '.Parameters[]|[(.Name|split("/")|last), .Value]|@tsv'
+)"
+
+if [ -z "${parameters}" ]; then
+  printf '!! ERROR: No Parameter Score data found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r name value; do
+  export "${name}"="${value}"
+done <<<"${parameters}"

--- a/scripts/read_parameters.sh
+++ b/scripts/read_parameters.sh
@@ -25,6 +25,9 @@ if [ -z "${parameters}" ]; then
   exit 1
 fi
 
+echo "Reading SSM parameters"
 while IFS=$'\t' read -r name value; do
   export "${name}"="${value}"
 done <<<"${parameters}"
+
+echo "Parameters exported"

--- a/scripts/read_secrets.sh
+++ b/scripts/read_secrets.sh
@@ -25,7 +25,9 @@ if [ -z "${secrets}" ]; then
   exit 1
 fi
 
+echo "Reading secrets"
 while IFS=$'\t' read -r arn name; do
+  echo -n "."
   value=$(aws secretsmanager get-secret-value --region "${REGION}" --secret-id "${arn}" | jq -r '.SecretString')
   export "${name}"="${value}"
 done <<<"${secrets}"

--- a/scripts/read_secrets.sh
+++ b/scripts/read_secrets.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
+ENVIRONMENT="${1}"
+configured_region="$(aws configure get region 2>/dev/null || true)"
+REGION="${configured_region:-eu-west-2}"
+
+if [ "$ENVIRONMENT" = "dev" ]; then
+  ENVIRONMENT="build"
+fi
+
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region "${REGION}" |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
+
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --region "${REGION}" --secret-id "${arn}" | jq -r '.SecretString')
+  export "${name}"="${value}"
+done <<<"${secrets}"

--- a/sync-dependencies.sh
+++ b/sync-dependencies.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure we are in the directory of the script
+cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
+
+if [ ! -d "authentication-frontend" ]; then
+  current_branch=$(git rev-parse --abbrev-ref HEAD)
+  git clone --depth=1 -b "$current_branch" git@github.com:govuk-one-login/authentication-frontend.git authentication-frontend ||
+  git clone --depth=1 -b main git@github.com:govuk-one-login/authentication-frontend.git authentication-frontend
+else
+  pushd authentication-frontend
+  git pull --depth=1 --rebase
+  popd
+fi


### PR DESCRIPTION
## What

Run `./provision-cloudfront-<environment>.sh` to deploy CloudFront distribution and additional dependencies described in the [CloudFront header](https://govukverify.atlassian.net/wiki/spaces/DID/pages/4026401532/Part+1+-+Deploying+CloudFront) trust initiative.

### Helper scripts

sync-dependencies.sh - deploys and maintains a shallow copy of authentication-frontend repository, in order to source several cloudformation templates used in the provision scripts

read_secrets.sh - extracts all secrets stored in AWS Secrets Manager named as `/deploy/\${Environment}/secret-name` and export to shell as `secret-name=value`

read_parameters.sh- extracts all parameters stored in AWS Systems Manager Parameter store named as `/deploy/\${Environment}/param-name` and export to shell as `param-name=value`

Both secrets and parameters are then injected to the provisioner script

## How to review

Run ./provision-cloudfront-build.sh. 

Example output posted in the JIRA ticket [AUT-3365]

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->


[AUT-3365]: https://govukverify.atlassian.net/browse/AUT-3365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ