### PR TITLE
AUT-3546 - Enable ECS Canary in authdev1 and staging envs

### DIFF
--- a/configuration/di-authentication-development/authdev1-frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/authdev1-frontend-pipeline/parameters.json
@@ -41,7 +41,7 @@
   },
   {
     "ParameterKey": "ECSCanaryDeployment",
-    "ParameterValue": "None"
+    "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
   },
   {
     "ParameterKey": "IncludePromotion",

--- a/configuration/di-authentication-staging/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-staging/frontend-pipeline/parameters.json
@@ -17,7 +17,7 @@
   },
   {
     "ParameterKey": "AdditionalCodeSigningVersionArns",
-    "ParameterValue": "arn:aws:signer:eu-west-2:216552277552:/signing-profiles/DynatraceSigner/5uwzCCGTPq"
+    "ParameterValue": "arn:aws:signer:eu-west-2:216552277552:/signing-profiles/DynatraceSigner/5uwzCCGTPq,arn:aws:signer:eu-west-2:354770603991:/signing-profiles/SigningProfile_SxeU7YX0F6Pb/HyVGO9gC7b"
   },
   {
     "ParameterKey": "AllowedAccounts",
@@ -30,6 +30,10 @@
   {
     "ParameterKey": "AllowedServiceTwo",
     "ParameterValue": "ECR & ECS"
+  },
+  {
+    "ParameterKey": "ECSCanaryDeployment",
+    "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
   },
   {
     "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",

--- a/provision-staging.sh
+++ b/provision-staging.sh
@@ -9,6 +9,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
 # --------------------------------------------
 export AWS_PROFILE=di-authentication-build-AWSAdministratorAccess
 aws sso login --profile "${AWS_PROFILE}"
+aws configure set region eu-west-2
 
 # shellcheck disable=SC1091
 source "./scripts/read_cloudformation_stack_outputs.sh" "aws-signer"


### PR DESCRIPTION
## What

Enable ECS Canary in authdev1 and staging envs

Issue: [AUT-3546]
<!-- Describe what you have changed and why -->


[AUT-3546]: https://govukverify.atlassian.net/browse/AUT-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ