### PR TITLE
AUT-3850: frontend pipeline build failure notifications setup

### DIFF
--- a/configuration/di-authentication-build/build-notifications/parameters.json
+++ b/configuration/di-authentication-build/build-notifications/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "InitialNotificationStack",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C07TMK4CGH2"
+  },
+  {
+    "ParameterKey": "EnrichedNotifications",
+    "ParameterValue": "False"
+  }
+]

--- a/configuration/di-authentication-build/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-build/frontend-pipeline/parameters.json
@@ -40,6 +40,14 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "SlackNotificationType",
+    "ParameterValue": "Failures"
+  },
+  {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
     "ParameterKey": "ECSCanaryDeployment",
     "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
   },

--- a/configuration/di-authentication-development/authdev1-frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/authdev1-frontend-pipeline/parameters.json
@@ -40,6 +40,14 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "SlackNotificationType",
+    "ParameterValue": "Failures"
+  },
+  {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
     "ParameterKey": "ECSCanaryDeployment",
     "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
   },

--- a/configuration/di-authentication-development/authdev2-frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/authdev2-frontend-pipeline/parameters.json
@@ -40,6 +40,14 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "SlackNotificationType",
+    "ParameterValue": "Failures"
+  },
+  {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
     "ParameterKey": "ECSCanaryDeployment",
     "ParameterValue": "None"
   },

--- a/configuration/di-authentication-development/build-notifications/parameters.json
+++ b/configuration/di-authentication-development/build-notifications/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "InitialNotificationStack",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C07TMK4CGH2"
+  },
+  {
+    "ParameterKey": "EnrichedNotifications",
+    "ParameterValue": "False"
+  }
+]

--- a/configuration/di-authentication-integration/build-notifications/parameters.json
+++ b/configuration/di-authentication-integration/build-notifications/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "InitialNotificationStack",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C07TMK4CGH2"
+  },
+  {
+    "ParameterKey": "EnrichedNotifications",
+    "ParameterValue": "False"
+  }
+]

--- a/configuration/di-authentication-integration/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-integration/frontend-pipeline/parameters.json
@@ -32,6 +32,14 @@
     "ParameterValue": "No"
   },
   {
+    "ParameterKey": "SlackNotificationType",
+    "ParameterValue": "Failures"
+  },
+  {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
     "ParameterKey": "ECSCanaryDeployment",
     "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
   },

--- a/configuration/di-authentication-production/build-notifications/parameters.json
+++ b/configuration/di-authentication-production/build-notifications/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "InitialNotificationStack",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C07TMK4CGH2"
+  },
+  {
+    "ParameterKey": "EnrichedNotifications",
+    "ParameterValue": "False"
+  }
+]

--- a/configuration/di-authentication-production/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-production/frontend-pipeline/parameters.json
@@ -32,6 +32,14 @@
     "ParameterValue": "No"
   },
   {
+    "ParameterKey": "SlackNotificationType",
+    "ParameterValue": "Failures"
+  },
+  {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
     "ParameterKey": "ECSCanaryDeployment",
     "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
   },

--- a/configuration/di-authentication-staging/build-notifications/parameters.json
+++ b/configuration/di-authentication-staging/build-notifications/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "InitialNotificationStack",
+    "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C07TMK4CGH2"
+  },
+  {
+    "ParameterKey": "EnrichedNotifications",
+    "ParameterValue": "False"
+  }
+]

--- a/configuration/di-authentication-staging/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-staging/frontend-pipeline/parameters.json
@@ -32,6 +32,14 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "SlackNotificationType",
+    "ParameterValue": "Failures"
+  },
+  {
+    "ParameterKey": "BuildNotificationStackName",
+    "ParameterValue": "build-notifications"
+  },
+  {
     "ParameterKey": "ECSCanaryDeployment",
     "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
   },

--- a/provision-build.sh
+++ b/provision-build.sh
@@ -24,7 +24,7 @@ export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-true}"
 
 # ./provisioner.sh "${AWS_ACCOUNT}" alerting-integration alerting-integration v1.0.6
 # ./provisioner.sh "${AWS_ACCOUNT}" api-gateway-logs api-gateway-logs v1.0.5
-# ./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.1
+./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.2
 # ./provisioner.sh "${AWS_ACCOUNT}" certificate-expiry certificate-expiry v1.1.1
 # ./provisioner.sh "${AWS_ACCOUNT}" checkov-hook checkov-hook LATEST
 ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST

--- a/provision-dev.sh
+++ b/provision-dev.sh
@@ -28,6 +28,8 @@ export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-true}"
 ./provisioner.sh "${AWS_ACCOUNT}" authdev1-vpc vpc v2.6.2
 ./provisioner.sh "${AWS_ACCOUNT}" authdev2-vpc vpc v2.6.2
 
+./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.2
+
 # NOTE: tag immutability is manually disabled for these ecr repositories
 ./provisioner.sh "${AWS_ACCOUNT}" frontend-image-repository container-image-repository v2.0.0
 ./provisioner.sh "${AWS_ACCOUNT}" basic-auth-sidecar-image-repository container-image-repository v2.0.0

--- a/provision-integration.sh
+++ b/provision-integration.sh
@@ -45,7 +45,7 @@ export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-true}"
 # ---------------------
 ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
 ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
-
+./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.2
 ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc v2.5.2
 
 # provision pipelines

--- a/provision-production.sh
+++ b/provision-production.sh
@@ -45,7 +45,7 @@ export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-true}"
 # ---------------------
 ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
 ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
-
+./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.2
 ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc v2.5.2
 
 # provision pipelines

--- a/provision-staging.sh
+++ b/provision-staging.sh
@@ -44,7 +44,7 @@ export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-true}"
 # ---------------------
 # ./provisioner.sh "${AWS_ACCOUNT}" alerting-integration alerting-integration v1.0.6
 # ./provisioner.sh "${AWS_ACCOUNT}" api-gateway-logs api-gateway-logs v1.0.5
-# ./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.1
+./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.2
 # ./provisioner.sh "${AWS_ACCOUNT}" certificate-expiry certificate-expiry v1.1.1
 # ./provisioner.sh "${AWS_ACCOUNT}" checkov-hook checkov-hook LATEST
 ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST


### PR DESCRIPTION
## What

- build-notifications stack setup for dev to production environments
- frontend pipelines configured to trigger notifications on failures 
- currently posting notifications to #di-auth-secure-pipeline-notifications channel

## How to review

Trigger a deployment or test or promotion failure in ci/cd pipeline
See notifications appearing in slack channel