### PR TITLE
AUT-3860: Support for retrieving signin-sp hosted zone id

### DIFF
--- a/provision-cloudfront.sh
+++ b/provision-cloudfront.sh
@@ -78,7 +78,7 @@ WAFv2WebACL=${!webacl:-"none"}
 #   no dependency
 # ----------------------------------------------------------
 PARAMETERS_FILE="configuration/${AWS_ACCOUNT}/${STACK_PREFIX}-cloudfront-certificate/parameters.json"
-HostedZoneID=${signin_route53_hostedzone_id:-""}
+HostedZoneID=${signin_sp_route53_hostedzone_id:-""}
 PARAMETERS=$(jq ". += [
                         {\"ParameterKey\":\"HostedZoneID\",\"ParameterValue\":\"${HostedZoneID}\"}
                     ] | tojson" -r "${PARAMETERS_FILE}")

--- a/scripts/read_parameters.sh
+++ b/scripts/read_parameters.sh
@@ -27,7 +27,9 @@ fi
 
 echo "Reading SSM parameters"
 while IFS=$'\t' read -r name value; do
-  export "${name}"="${value}"
+  echo -n "."
+  name_in_underscore=$(echo "${name}" | tr "-" "_")
+  export "${name_in_underscore}"="${value}"
 done <<<"${parameters}"
 
 echo "Parameters exported"


### PR DESCRIPTION
## What

Workaround in scripts/read_parameters.sh to convert hyphens to underscore
Retrieve signin-sp hosted zone id, required for certificate validation

<!-- Describe what you have changed and why -->

## How to review

In order to deploy in i.e. build environment, run `./provision-cloudfront.sh build`