### PR TITLE
AUT-3694 copy zone id record set in prod

### DIFF
--- a/dns-records-signin-integration.json
+++ b/dns-records-signin-integration.json
@@ -13,30 +13,6 @@
                 "Type": "CNAME",
                 "TTL": 60
             }
-        },
-        {
-            "Action": "CREATE",
-            "ResourceRecordSet" : {
-                "Name": "signin.integration.account.gov.uk",
-                "Type": "A",
-                "AliasTarget": {
-                    "HostedZoneId": "Z2FDTNDATAQYW2",
-                    "DNSName": "d3dw1x63k50a79.cloudfront.net.",
-                    "EvaluateTargetHealth": false
-                }
-            }
-        },
-        {
-            "Action": "CREATE",
-            "ResourceRecordSet" : {
-                "Name": "origin.signin.integration.account.gov.uk",
-                "Type": "A",
-                "AliasTarget": {
-                    "HostedZoneId": "ZHURV8PSTC4K8",
-                    "DNSName": "dualstack.integration-frontend-1951285918.eu-west-2.elb.amazonaws.com.",
-                    "EvaluateTargetHealth": false
-                }
-            }
         }
     ]
 }

--- a/dns-records-signin-integration.json
+++ b/dns-records-signin-integration.json
@@ -1,0 +1,42 @@
+{
+    "Comment": "Old records",
+    "Changes": [
+        {
+            "Action": "CREATE",
+            "ResourceRecordSet" : {
+                "ResourceRecords": [
+                    {
+                        "Value": "_ba302f52bc6aafad791a61a8d09513ac.bgpjyrktby.acm-validations.aws."
+                    }
+                ],
+                "Name": "_f91fbc1b2acbfc5fd8b22ea327e958e0.signin.integration.account.gov.uk.",
+                "Type": "CNAME",
+                "TTL": 60
+            }
+        },
+        {
+            "Action": "CREATE",
+            "ResourceRecordSet" : {
+                "Name": "signin.integration.account.gov.uk",
+                "Type": "A",
+                "AliasTarget": {
+                    "HostedZoneId": "Z2FDTNDATAQYW2",
+                    "DNSName": "d3dw1x63k50a79.cloudfront.net.",
+                    "EvaluateTargetHealth": false
+                }
+            }
+        },
+        {
+            "Action": "CREATE",
+            "ResourceRecordSet" : {
+                "Name": "origin.signin.integration.account.gov.uk",
+                "Type": "A",
+                "AliasTarget": {
+                    "HostedZoneId": "ZHURV8PSTC4K8",
+                    "DNSName": "dualstack.integration-frontend-1951285918.eu-west-2.elb.amazonaws.com.",
+                    "EvaluateTargetHealth": false
+                }
+            }
+        }
+    ]
+}

--- a/dns-records-signin-prod.json
+++ b/dns-records-signin-prod.json
@@ -1,0 +1,43 @@
+{
+    "Comment": "Old records",
+    "changes": [
+        {
+            "Action": "CREATE",
+            "ResourceRecordSet" : {
+                "ResourceRecords": [
+                    {
+                        "Value": "_ebff5f58d2ed26c9751cfcc5562bbb40.bgpjyrktby.acm-validations.aws."
+                    }
+                ],
+                "Name": "_48db4d437de3805d5078aba1b0c63f5c.signin.account.gov.uk.",
+                "Type": "CNAME",
+                "TTL": 60
+            }
+
+        },
+        {
+            "Action": "CREATE",
+            "ResourceRecordSet" : {
+                "Name": "signin.account.gov.uk.",
+                "Type": "A",
+                "AliasTarget": {
+                    "HostedZoneId": "Z2FDTNDATAQYW2",
+                    "DNSName": "d1sj2b5tywgixi.cloudfront.net.",
+                    "EvaluateTargetHealth": false
+                }
+            }
+        },
+        {
+            "Action": "CREATE",
+            "ResourceRecordSet" : {
+                "Name": "origin.signin.account.gov.uk.",
+                "Type": "A",
+                "AliasTarget": {
+                    "HostedZoneId": "ZHURV8PSTC4K8",
+                    "DNSName": "dualstack.production-frontend-1140310834.eu-west-2.elb.amazonaws.com.",
+                    "EvaluateTargetHealth": false
+                }
+            }
+        }
+    ]
+}

--- a/dns-records-signin-production.json
+++ b/dns-records-signin-production.json
@@ -1,6 +1,6 @@
 {
     "Comment": "Old records",
-    "changes": [
+    "Changes": [
         {
             "Action": "CREATE",
             "ResourceRecordSet" : {
@@ -13,7 +13,6 @@
                 "Type": "CNAME",
                 "TTL": 60
             }
-
         },
         {
             "Action": "CREATE",

--- a/dns-records-signin-production.json
+++ b/dns-records-signin-production.json
@@ -13,30 +13,6 @@
                 "Type": "CNAME",
                 "TTL": 60
             }
-        },
-        {
-            "Action": "CREATE",
-            "ResourceRecordSet" : {
-                "Name": "signin.account.gov.uk.",
-                "Type": "A",
-                "AliasTarget": {
-                    "HostedZoneId": "Z2FDTNDATAQYW2",
-                    "DNSName": "d1sj2b5tywgixi.cloudfront.net.",
-                    "EvaluateTargetHealth": false
-                }
-            }
-        },
-        {
-            "Action": "CREATE",
-            "ResourceRecordSet" : {
-                "Name": "origin.signin.account.gov.uk.",
-                "Type": "A",
-                "AliasTarget": {
-                    "HostedZoneId": "ZHURV8PSTC4K8",
-                    "DNSName": "dualstack.production-frontend-1140310834.eu-west-2.elb.amazonaws.com.",
-                    "EvaluateTargetHealth": false
-                }
-            }
         }
     ]
 }

--- a/migrate-record-set.sh
+++ b/migrate-record-set.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure we are in the directory of the script
+cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
+
+[ $# = 1 ] || { echo "Usage: $(basename "$0" .sh) newzoneid" >&1; exit 1; }
+
+export AWS_PROFILE=di-authentication-production-AWSAdministratorAccess
+aws sso login --profile "${AWS_PROFILE}"
+aws configure set region eu-west-2
+
+# Created the DNS recird in new Zone id
+aws route53 change-resource-record-sets --hosted-zone-id "${1}" --change-batch file://dns-records-signin-prod.json

--- a/migrate-record-set.sh
+++ b/migrate-record-set.sh
@@ -10,5 +10,5 @@ export AWS_PROFILE=di-authentication-production-AWSAdministratorAccess
 aws sso login --profile "${AWS_PROFILE}"
 aws configure set region eu-west-2
 
-# Created the DNS recird in new Zone id
+# Create the DNS record in new Zone id
 aws route53 change-resource-record-sets --hosted-zone-id "${1}" --change-batch file://dns-records-signin-prod.json

--- a/migrate-record-set.sh
+++ b/migrate-record-set.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 # Ensure we are in the directory of the script
 cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
 
-[ $# = 1 ] || { echo "Usage: $(basename "$0" .sh) newzoneid" >&1; exit 1; }
+[ $# = 2 ] || { echo "Usage: $(basename "$0" .sh) newzoneid env(production or integration )" >&2; exit 1; }
 
-export AWS_PROFILE=di-authentication-production-AWSAdministratorAccess
+export AWS_PROFILE=di-authentication-"${2}"-AWSAdministratorAccess
 aws sso login --profile "${AWS_PROFILE}"
 aws configure set region eu-west-2
 
 # Create the DNS record in new Zone id
-aws route53 change-resource-record-sets --hosted-zone-id "${1}" --change-batch file://dns-records-signin-prod.json
+aws route53 change-resource-record-sets --hosted-zone-id "${1}" --change-batch file://dns-records-signin-"${2}".json


### PR DESCRIPTION
## What

Adding Script to copy  prod DNS records from existing signin ZONE Id to New signin ZONE Id in new AWS account.

Note: This script only creates a DNS record in new Zone ID however to make this records we need to do Name server Delegation in root domain 

## How to review
1. Code Review