### PR TITLE
AUT-3944: Prod build-notifications stack is the InitialNotificationStack

### DIFF
--- a/configuration/di-authentication-production/build-notifications/parameters.json
+++ b/configuration/di-authentication-production/build-notifications/parameters.json
@@ -1,7 +1,7 @@
 [
   {
     "ParameterKey": "InitialNotificationStack",
-    "ParameterValue": "No"
+    "ParameterValue": "Yes"
   },
   {
     "ParameterKey": "SlackChannelId",


### PR DESCRIPTION
## What

Prod build-notifications stack is the InitialNotificationStack
Updated parameters.json to reflect that

## How to review

`./provision-production.sh` returns no change