### PR TITLE
AUT-3689: Build provision script refactor, parameters for migration intermediate stages

### DIFF
--- a/configuration/di-authentication-build/auth-fe-cloudfront-live-certificate/parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront-live-certificate/parameters.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "signin.build.account.gov.uk"
+  }
+]

--- a/configuration/di-authentication-build/auth-fe-cloudfront-wildcard-certificate/parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront-wildcard-certificate/parameters.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "*.build.account.gov.uk"
+  }
+]

--- a/configuration/di-authentication-build/auth-fe-cloudfront/live-parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront/live-parameters.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ParameterKey": "AddWWWPrefix",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "signin.build.account.gov.uk"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "csls_cw_logs_destination_prodpython-2"
+  }
+]

--- a/configuration/di-authentication-build/auth-fe-cloudfront/wildcard-parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront/wildcard-parameters.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ParameterKey": "AddWWWPrefix",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "*.build.account.gov.uk"
+  },
+  {
+    "ParameterKey": "OriginAlias",
+    "ParameterValue": "origin.signin.build.account.gov.uk"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "csls_cw_logs_destination_prodpython-2"
+  }
+]

--- a/configuration/di-authentication-build/hosted-zones-and-records/parameters.json
+++ b/configuration/di-authentication-build/hosted-zones-and-records/parameters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
+    "ParameterKey": "EndpointSuffix",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "DeployHostedZone",
+    "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "Yes"
+  }
+]

--- a/configuration/di-authentication-build/hosted-zones-and-records/zone-only-parameters.json
+++ b/configuration/di-authentication-build/hosted-zones-and-records/zone-only-parameters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
+    "ParameterKey": "EndpointSuffix",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "DeployHostedZone",
+    "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "No"
+  }
+]

--- a/provision-staging.sh
+++ b/provision-staging.sh
@@ -6,7 +6,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
 
 function usage {
     cat <<USAGE
-  Script to bootstrap staging account
+  Script to bootstrap di-authentication-staging account
 
   Usage:
     $0 [-b|--base-stacks] [-p|--pipelines] [-t|--transitional-zone-resources] [-l|--live-zone-resources <zone-only|all>]


### PR DESCRIPTION
## What

Changes:

- Build provision script refactor: divided into functional sections i.e base_stacks, pipelines etc and deployment controlled via args
- Stack input parameters.json files for intermediate and final migration stages

Issue: [AUT-3689]

<!-- Describe what you have changed and why -->

## How to review

Run `./provision-build.sh` and `./provision-cloudfront.sh`. Should print usage if no args, specific stacks updated as per args input

[AUT-3689]: https://govukverify.atlassian.net/browse/AUT-3689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ