### PR TITLE
AUT-3693: Integration provision script refactor, parameters for migration intermediate stages

### DIFF
--- a/configuration/di-authentication-integration/auth-fe-cloudfront-live-certificate/parameters.json
+++ b/configuration/di-authentication-integration/auth-fe-cloudfront-live-certificate/parameters.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "signin.integration.account.gov.uk"
+  }
+]

--- a/configuration/di-authentication-integration/auth-fe-cloudfront-wildcard-certificate/parameters.json
+++ b/configuration/di-authentication-integration/auth-fe-cloudfront-wildcard-certificate/parameters.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ParameterKey": "DomainName",
+    "ParameterValue": "*.integration.account.gov.uk"
+  }
+]

--- a/configuration/di-authentication-integration/auth-fe-cloudfront/live-parameters.json
+++ b/configuration/di-authentication-integration/auth-fe-cloudfront/live-parameters.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ParameterKey": "AddWWWPrefix",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "signin.integration.account.gov.uk"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "csls_cw_logs_destination_prodpython-2"
+  }
+]

--- a/configuration/di-authentication-integration/auth-fe-cloudfront/wildcard-parameters.json
+++ b/configuration/di-authentication-integration/auth-fe-cloudfront/wildcard-parameters.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ParameterKey": "AddWWWPrefix",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DistributionAlias",
+    "ParameterValue": "*.integration.account.gov.uk"
+  },
+  {
+    "ParameterKey": "OriginAlias",
+    "ParameterValue": "origin.signin.integration.account.gov.uk"
+  },
+  {
+    "ParameterKey": "FraudHeaderEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "StandardLoggingEnabled",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "LogDestination",
+    "ParameterValue": "csls_cw_logs_destination_prodpython-2"
+  }
+]

--- a/configuration/di-authentication-integration/hosted-zones-and-records/parameters.json
+++ b/configuration/di-authentication-integration/hosted-zones-and-records/parameters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "integration"
+  },
+  {
+    "ParameterKey": "EndpointSuffix",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "DeployHostedZone",
+    "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "Yes"
+  }
+]

--- a/configuration/di-authentication-integration/hosted-zones-and-records/zone-only-parameters.json
+++ b/configuration/di-authentication-integration/hosted-zones-and-records/zone-only-parameters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "integration"
+  },
+  {
+    "ParameterKey": "EndpointSuffix",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "DeployHostedZone",
+    "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "DeployCertificate",
+    "ParameterValue": "No"
+  }
+]

--- a/provision-integration.sh
+++ b/provision-integration.sh
@@ -4,6 +4,55 @@ set -euo pipefail
 # Ensure we are in the directory of the script
 cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
 
+function usage {
+    cat <<USAGE
+  Script to bootstrap di-authentication-integration account
+
+  Usage:
+    $0 [-b|--base-stacks] [-p|--pipelines] [-t|--transitional-zone-resources] [-l|--live-zone-resources <zone-only|all>]
+
+  Options:
+    -b, --base-stacks                      Provision base stacks
+    -p, --pipelines                        Provision secure pipelines
+    -t, --transitional-zone-resources      Provision transitional hosted zone, certificates and SSM params
+    -l, --live-zone-resources              Provision live hosted zone, certificates and SSM params
+USAGE
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+PROVISION_BASE_STACKS=false
+PROVISION_PIPELINES=false
+PROVISION_TRANSITIONAL_HOSTED_ZONE_AND_RECORDS=false
+PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=false
+
+while [[ $# -gt 0 ]]; do
+    case "${1}" in
+        -b | --base-stacks)
+            PROVISION_BASE_STACKS=true
+            ;;
+        -p | --pipelines)
+            PROVISION_PIPELINES=true
+            ;;
+        -t | --transitional-zone-resources)
+            PROVISION_TRANSITIONAL_HOSTED_ZONE_AND_RECORDS=true
+            ;;
+        -l | --live-zone-resources)
+            PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=true
+            DEPLOY_CONFIG=${2}
+            shift
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 # --------------------------------------------
 # extract outputs from stacks in build account
 # --------------------------------------------
@@ -41,34 +90,77 @@ export AWS_PAGER=
 export SKIP_AWS_AUTHENTICATION="${SKIP_AWS_AUTHENTICATION:-true}"
 export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-false}"
 
-# provision base stacks
-# ---------------------
-./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
-./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
-./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.3
-
-VPC_TEMPLATE_VERSION="v2.7.0"
-./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
-
-# provision pipelines
-# -------------------
-PIPELINE_TEMPLATE_VERSION="v2.69.13"
-PARAMETERS_FILE="configuration/$AWS_ACCOUNT/frontend-pipeline/parameters.json"
-PARAMETERS=$(jq ". += [
-                        {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
-                        {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
-                        {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"},
-                        {\"ParameterKey\":\"ArtifactSourceBucketArn\",\"ParameterValue\":\"${ArtifactSourceBucketArn}\"},
-                        {\"ParameterKey\":\"ArtifactSourceBucketEventTriggerRoleArn\",\"ParameterValue\":\"${ArtifactSourceBucketEventTriggerRoleArn}\"}
-                    ] | tojson" -r "${PARAMETERS_FILE}")
-
-TMP_PARAM_FILE=$(mktemp)
-echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
-PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" frontend-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
-
-# setting up domains
-# ------------------
+# -------------------------------------------------
 # shallow clone templates from authentication repos
+# -------------------------------------------------
 ./sync-dependencies.sh
 
-TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" dns-zones-and-records dns LATEST
+# ---------------------
+# provision base stacks
+# ---------------------
+function provision_base_stacks {
+    aws configure set region eu-west-2
+    ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
+    ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
+    ./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.3
+
+    VPC_TEMPLATE_VERSION="v2.7.0"
+    ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
+}
+
+# -------------------
+# provision pipelines
+# -------------------
+function provision_pipeline {
+    PIPELINE_TEMPLATE_VERSION="v2.69.13"
+    PARAMETERS_FILE="configuration/$AWS_ACCOUNT/frontend-pipeline/parameters.json"
+    PARAMETERS=$(jq ". += [
+                            {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
+                            {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
+                            {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"},
+                            {\"ParameterKey\":\"ArtifactSourceBucketArn\",\"ParameterValue\":\"${ArtifactSourceBucketArn}\"},
+                            {\"ParameterKey\":\"ArtifactSourceBucketEventTriggerRoleArn\",\"ParameterValue\":\"${ArtifactSourceBucketEventTriggerRoleArn}\"}
+                        ] | tojson" -r "${PARAMETERS_FILE}")
+
+    TMP_PARAM_FILE=$(mktemp)
+    echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
+    aws configure set region eu-west-2
+    PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" frontend-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
+}
+
+# ------------------
+# setting up domains
+# ------------------
+function provision_transitional_hosted_zone_and_records {
+    # deploy signin-sp domain resources
+    aws configure set region eu-west-2
+    TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" dns-zones-and-records dns LATEST
+}
+
+function provision_live_hosted_zone_and_records {
+    case "${DEPLOY_CONFIG}" in
+        zone-only)
+            PARAMETERS_FILE="configuration/$AWS_ACCOUNT/hosted-zones-and-records/zone-only-parameters.json"
+            ;;
+        all)
+            PARAMETERS_FILE="configuration/$AWS_ACCOUNT/hosted-zones-and-records/parameters.json"
+            ;;
+        *)
+            echo "Unknown live domain deploy configuration: $DEPLOY_CONFIG"
+            usage
+            exit 1
+            ;;
+    esac
+
+    # deploy signin domain resources
+    aws configure set region eu-west-2
+    PARAMETERS_FILE=$PARAMETERS_FILE TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" hosted-zones-and-records dns LATEST
+}
+
+# --------------------
+# Provision components
+# --------------------
+[ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
+[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
+[ "${PROVISION_TRANSITIONAL_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_transitional_hosted_zone_and_records
+[ "${PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_live_hosted_zone_and_records


### PR DESCRIPTION
## What

Changes:

- Build provision script refactor: divided into functional sections i.e base_stacks, pipelines etc and deployment controlled via args
- Stack input parameters.json files for intermediate and final migration stages

Issue: [AUT-3693]

## How to review

Run `./provision-build.sh` and `./provision-cloudfront.sh`. Should print usage if no args, specific stacks updated as per args input


[AUT-3693]: https://govukverify.atlassian.net/browse/AUT-3693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ