### PR TITLE
AUT-3943 - Disable ECS canary deployment in staging

### DIFF
--- a/configuration/di-authentication-staging/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-staging/frontend-pipeline/parameters.json
@@ -41,7 +41,7 @@
   },
   {
     "ParameterKey": "ECSCanaryDeployment",
-    "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
+    "ParameterValue": "None"
   },
   {
     "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",


### PR DESCRIPTION
## What

Disable ECS canary deployment in staging
Issue: [AUT-3943]

## How to review

Deploy to staging `./provision-staging.sh -p`


[AUT-3943]: https://govukverify.atlassian.net/browse/AUT-3943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ