### PR TITLE
AUT-3941 - Authdevs moved to shared vpc, provision-dev.sh refactored to match higher envs

### DIFF
--- a/configuration/di-authentication-development/authdev1-frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/authdev1-frontend-pipeline/parameters.json
@@ -17,7 +17,7 @@
   },
   {
     "ParameterKey": "VpcStackName",
-    "ParameterValue": "authdev1-vpc"
+    "ParameterValue": "vpc"
   },
   {
     "ParameterKey": "OneLoginRepositoryName",

--- a/configuration/di-authentication-development/authdev2-frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/authdev2-frontend-pipeline/parameters.json
@@ -17,7 +17,7 @@
   },
   {
     "ParameterKey": "VpcStackName",
-    "ParameterValue": "authdev2-vpc"
+    "ParameterValue": "vpc"
   },
   {
     "ParameterKey": "OneLoginRepositoryName",

--- a/provision-dev.sh
+++ b/provision-dev.sh
@@ -26,8 +26,7 @@ export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-true}"
 ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
 
 VPC_TEMPLATE_VERSION="v2.7.0"
-# NOTE:  DEV VPC stack deleted Dev VPC  will be created again when we start building DEV env
-# ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc v2.5.2
+./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 ./provisioner.sh "${AWS_ACCOUNT}" authdev1-vpc vpc "${VPC_TEMPLATE_VERSION}"
 ./provisioner.sh "${AWS_ACCOUNT}" authdev2-vpc vpc "${VPC_TEMPLATE_VERSION}"
 

--- a/provision-dev.sh
+++ b/provision-dev.sh
@@ -4,6 +4,48 @@ set -euo pipefail
 # Ensure we are in the directory of the script
 cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 || exit
 
+function usage {
+    cat <<USAGE
+  Script to bootstrap di-authentication-development account
+
+  Usage:
+    $0 [-b|--base-stacks] [-p|--pipelines] [-t|--transitional-zone-resources]
+
+  Options:
+    -b, --base-stacks                      Provision base stacks
+    -p, --pipelines                        Provision secure pipelines
+    -t, --transitional-zone-resources      Provision transitional hosted zone, certificates and SSM params
+USAGE
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+PROVISION_BASE_STACKS=false
+PROVISION_PIPELINES=false
+PROVISION_TRANSITIONAL_HOSTED_ZONE_AND_RECORDS=false
+
+while [[ $# -gt 0 ]]; do
+    case "${1}" in
+        -b | --base-stacks)
+            PROVISION_BASE_STACKS=true
+            ;;
+        -p | --pipelines)
+            PROVISION_PIPELINES=true
+            ;;
+        -t | --transitional-zone-resources)
+            PROVISION_TRANSITIONAL_HOSTED_ZONE_AND_RECORDS=true
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 # ----------------------------
 # build account initialisation
 # ----------------------------
@@ -14,102 +56,124 @@ aws configure set region eu-west-2
 
 export AWS_PAGER=
 export SKIP_AWS_AUTHENTICATION="${SKIP_AWS_AUTHENTICATION:-true}"
-export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-true}"
+export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-false}"
 
-# provision base stacks
-# ---------------------
-./provisioner.sh "${AWS_ACCOUNT}" aws-signer signer v1.0.8
-./provisioner.sh "${AWS_ACCOUNT}" github-identity github-identity v1.1.1
-./provisioner.sh "${AWS_ACCOUNT}" container-signer container-signer v1.1.2
-
-./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
-./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
-
-VPC_TEMPLATE_VERSION="v2.7.0"
-./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
-
-./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.3
-
-CONTAINER_IMAGE_TEMPLATE_VERSION="v2.0.1"
-# NOTE: tag immutability is manually disabled for these ecr repositories
-./provisioner.sh "${AWS_ACCOUNT}" frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" basic-auth-sidecar-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-
-# NOTE: tag immutability is manually disabled for these ecr repositories
-./provisioner.sh "${AWS_ACCOUNT}" authdev1-frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" authdev1-basic-auth-sidecar-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" authdev1-service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-
-# NOTE: tag immutability is manually disabled for these ecr repositories
-./provisioner.sh "${AWS_ACCOUNT}" authdev2-frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" authdev2-basic-auth-sidecar-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" authdev2-service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-
-# provision pipelines
-# -------------------
-PIPELINE_TEMPLATE_VERSION="v2.69.13"
-
-# shellcheck disable=SC1091
-source "./scripts/read_cloudformation_stack_outputs.sh" "aws-signer"
-SigningProfileArn=${CFN_aws_signer_SigningProfileArn:-"none"}
-SigningProfileVersionArn=${CFN_aws_signer_SigningProfileVersionArn:-"none"}
-
-# shellcheck disable=SC1091
-source "./scripts/read_cloudformation_stack_outputs.sh" "container-signer"
-ContainerSignerKmsKeyArn=${CFN_container_signer_ContainerSignerKmsKeyArn:-"none"}
-
-# dev-frontend
-PARAMETERS_FILE="configuration/$AWS_ACCOUNT/frontend-pipeline/parameters.json"
-PARAMETERS=$(jq ". += [
-                        {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
-                        {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
-                        {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
-                    ] | tojson" -r "${PARAMETERS_FILE}")
-
-TMP_PARAM_FILE=$(mktemp)
-echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
-PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" frontend-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
-
-# authdev1-frontend
-PARAMETERS_FILE="configuration/$AWS_ACCOUNT/authdev1-frontend-pipeline/parameters.json"
-PARAMETERS=$(jq ". += [
-                        {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
-                        {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
-                        {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
-                    ] | tojson" -r "${PARAMETERS_FILE}")
-
-TMP_PARAM_FILE=$(mktemp)
-echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
-PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" authdev1-frontend-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
-
-# authdev2-frontend
-PARAMETERS_FILE="configuration/$AWS_ACCOUNT/authdev2-frontend-pipeline/parameters.json"
-PARAMETERS=$(jq ". += [
-                        {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
-                        {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
-                        {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
-                    ] | tojson" -r "${PARAMETERS_FILE}")
-
-TMP_PARAM_FILE=$(mktemp)
-echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
-PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" authdev2-frontend-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
-
-# dev ipv-stub pipeline
-PARAMETERS_FILE="configuration/$AWS_ACCOUNT/dev-ipv-stub-pipeline/parameters.json"
-PARAMETERS=$(jq ". += [
-                        {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
-                        {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
-                        {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
-                    ] | tojson" -r "${PARAMETERS_FILE}")
-
-TMP_PARAM_FILE=$(mktemp)
-echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
-PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" ipv-stub-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
-
-# setting up domains
-# ------------------
+# -------------------------------------------------
 # shallow clone templates from authentication repos
+# -------------------------------------------------
 ./sync-dependencies.sh
 
-TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" dns-zones-and-records dns LATEST
+# ---------------------
+# provision base stacks
+# ---------------------
+function provision_base_stacks {
+    aws configure set region eu-west-2
+
+    ./provisioner.sh "${AWS_ACCOUNT}" aws-signer signer v1.0.8
+    ./provisioner.sh "${AWS_ACCOUNT}" github-identity github-identity v1.1.1
+    ./provisioner.sh "${AWS_ACCOUNT}" container-signer container-signer v1.1.2
+
+    ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
+    ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
+
+    VPC_TEMPLATE_VERSION="v2.7.0"
+    ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
+
+    ./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.3
+
+    CONTAINER_IMAGE_TEMPLATE_VERSION="v2.0.1"
+    # NOTE: tag immutability is manually disabled for these ecr repositories
+    ./provisioner.sh "${AWS_ACCOUNT}" frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+    ./provisioner.sh "${AWS_ACCOUNT}" basic-auth-sidecar-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+    ./provisioner.sh "${AWS_ACCOUNT}" service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+
+    # NOTE: tag immutability is manually disabled for these ecr repositories
+    ./provisioner.sh "${AWS_ACCOUNT}" authdev1-frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+    ./provisioner.sh "${AWS_ACCOUNT}" authdev1-basic-auth-sidecar-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+    ./provisioner.sh "${AWS_ACCOUNT}" authdev1-service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+
+    # NOTE: tag immutability is manually disabled for these ecr repositories
+    ./provisioner.sh "${AWS_ACCOUNT}" authdev2-frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+    ./provisioner.sh "${AWS_ACCOUNT}" authdev2-basic-auth-sidecar-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+    ./provisioner.sh "${AWS_ACCOUNT}" authdev2-service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+}
+
+# -------------------
+# provision pipelines
+# -------------------
+function provision_pipeline {
+    PIPELINE_TEMPLATE_VERSION="v2.69.13"
+    aws configure set region eu-west-2
+
+    # shellcheck disable=SC1091
+    source "./scripts/read_cloudformation_stack_outputs.sh" "aws-signer"
+    SigningProfileArn=${CFN_aws_signer_SigningProfileArn:-"none"}
+    SigningProfileVersionArn=${CFN_aws_signer_SigningProfileVersionArn:-"none"}
+
+    # shellcheck disable=SC1091
+    source "./scripts/read_cloudformation_stack_outputs.sh" "container-signer"
+    ContainerSignerKmsKeyArn=${CFN_container_signer_ContainerSignerKmsKeyArn:-"none"}
+
+    # dev-frontend
+    PARAMETERS_FILE="configuration/$AWS_ACCOUNT/frontend-pipeline/parameters.json"
+    PARAMETERS=$(jq ". += [
+                            {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
+                            {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
+                            {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
+                        ] | tojson" -r "${PARAMETERS_FILE}")
+
+    TMP_PARAM_FILE=$(mktemp)
+    echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
+    PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" frontend-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
+
+    # authdev1-frontend
+    PARAMETERS_FILE="configuration/$AWS_ACCOUNT/authdev1-frontend-pipeline/parameters.json"
+    PARAMETERS=$(jq ". += [
+                            {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
+                            {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
+                            {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
+                        ] | tojson" -r "${PARAMETERS_FILE}")
+
+    TMP_PARAM_FILE=$(mktemp)
+    echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
+    PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" authdev1-frontend-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
+
+    # authdev2-frontend
+    PARAMETERS_FILE="configuration/$AWS_ACCOUNT/authdev2-frontend-pipeline/parameters.json"
+    PARAMETERS=$(jq ". += [
+                            {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
+                            {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
+                            {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
+                        ] | tojson" -r "${PARAMETERS_FILE}")
+
+    TMP_PARAM_FILE=$(mktemp)
+    echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
+    PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" authdev2-frontend-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
+
+    # dev ipv-stub pipeline
+    PARAMETERS_FILE="configuration/$AWS_ACCOUNT/dev-ipv-stub-pipeline/parameters.json"
+    PARAMETERS=$(jq ". += [
+                            {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
+                            {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
+                            {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
+                        ] | tojson" -r "${PARAMETERS_FILE}")
+
+    TMP_PARAM_FILE=$(mktemp)
+    echo "$PARAMETERS" | jq -r > "$TMP_PARAM_FILE"
+    PARAMETERS_FILE=$TMP_PARAM_FILE ./provisioner.sh "${AWS_ACCOUNT}" ipv-stub-pipeline sam-deploy-pipeline "${PIPELINE_TEMPLATE_VERSION}"
+}
+
+# ------------------
+# setting up domains
+# ------------------
+function provision_transitional_hosted_zone_and_records {
+    aws configure set region eu-west-2
+    TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" dns-zones-and-records dns LATEST
+}
+
+# --------------------
+# Provision components
+# --------------------
+[ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
+[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
+[ "${PROVISION_TRANSITIONAL_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_transitional_hosted_zone_and_records

--- a/provision-dev.sh
+++ b/provision-dev.sh
@@ -27,7 +27,6 @@ export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-true}"
 
 VPC_TEMPLATE_VERSION="v2.7.0"
 ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" authdev1-vpc vpc "${VPC_TEMPLATE_VERSION}"
 
 ./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.3
 

--- a/provision-dev.sh
+++ b/provision-dev.sh
@@ -28,7 +28,6 @@ export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-true}"
 VPC_TEMPLATE_VERSION="v2.7.0"
 ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 ./provisioner.sh "${AWS_ACCOUNT}" authdev1-vpc vpc "${VPC_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" authdev2-vpc vpc "${VPC_TEMPLATE_VERSION}"
 
 ./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.3
 
@@ -42,21 +41,11 @@ CONTAINER_IMAGE_TEMPLATE_VERSION="v2.0.1"
 ./provisioner.sh "${AWS_ACCOUNT}" authdev1-frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
 ./provisioner.sh "${AWS_ACCOUNT}" authdev1-basic-auth-sidecar-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
 ./provisioner.sh "${AWS_ACCOUNT}" authdev1-service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" authdev1-acceptance-test-image-repository test-image-repository v1.2.0
 
 # NOTE: tag immutability is manually disabled for these ecr repositories
 ./provisioner.sh "${AWS_ACCOUNT}" authdev2-frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
 ./provisioner.sh "${AWS_ACCOUNT}" authdev2-basic-auth-sidecar-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
 ./provisioner.sh "${AWS_ACCOUNT}" authdev2-service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
-./provisioner.sh "${AWS_ACCOUNT}" authdev2-acceptance-test-image-repository test-image-repository v1.2.0
-
-# shellcheck disable=SC1091
-source "./scripts/read_cloudformation_stack_outputs.sh" "authdev1-acceptance-test-image-repository"
-Authdev1TestImageRepositoryUri=${CFN_authdev1_acceptance_test_image_repository_TestRunnerImageEcrRepositoryUri:-"none"}
-
-# shellcheck disable=SC1091
-source "./scripts/read_cloudformation_stack_outputs.sh" "authdev2-acceptance-test-image-repository"
-Authdev2TestImageRepositoryUri=${CFN_authdev2_acceptance_test_image_repository_TestRunnerImageEcrRepositoryUri:-"none"}
 
 # provision pipelines
 # -------------------
@@ -88,8 +77,7 @@ PARAMETERS_FILE="configuration/$AWS_ACCOUNT/authdev1-frontend-pipeline/parameter
 PARAMETERS=$(jq ". += [
                         {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
                         {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
-                        {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"},
-                        {\"ParameterKey\":\"TestImageRepositoryUri\",\"ParameterValue\":\"${Authdev1TestImageRepositoryUri}\"}
+                        {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
                     ] | tojson" -r "${PARAMETERS_FILE}")
 
 TMP_PARAM_FILE=$(mktemp)
@@ -101,8 +89,7 @@ PARAMETERS_FILE="configuration/$AWS_ACCOUNT/authdev2-frontend-pipeline/parameter
 PARAMETERS=$(jq ". += [
                         {\"ParameterKey\":\"ContainerSignerKmsKeyArn\",\"ParameterValue\":\"${ContainerSignerKmsKeyArn}\"},
                         {\"ParameterKey\":\"SigningProfileArn\",\"ParameterValue\":\"${SigningProfileArn}\"},
-                        {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"},
-                        {\"ParameterKey\":\"TestImageRepositoryUri\",\"ParameterValue\":\"${Authdev2TestImageRepositoryUri}\"}
+                        {\"ParameterKey\":\"SigningProfileVersionArn\",\"ParameterValue\":\"${SigningProfileVersionArn}\"}
                     ] | tojson" -r "${PARAMETERS_FILE}")
 
 TMP_PARAM_FILE=$(mktemp)


### PR DESCRIPTION
## What

1. Authdevs moved to shared vpc
2. provision-dev.sh refactored to match higher envs

Issue: [AUT-3941]

provision-dev.sh supports input params
```
$ ./provision-dev.sh 
  Script to bootstrap di-authentication-development account

  Usage:
    ./provision-dev.sh [-b|--base-stacks] [-p|--pipelines] [-t|--transitional-zone-resources]

  Options:
    -b, --base-stacks                      Provision base stacks
    -p, --pipelines                        Provision secure pipelines
    -t, --transitional-zone-resources      Provision transitional hosted zone, certificates and SSM params
```

## How to review

Update pipelines by running `./provision-dev.sh  -p`

[AUT-3941]: https://govukverify.atlassian.net/browse/AUT-3941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ