### PR TITLE
AUT-3990: Disable frontend ECS Blue/green deployment

### DIFF
--- a/configuration/di-authentication-build/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-build/frontend-pipeline/parameters.json
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ECSCanaryDeployment",
-    "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
+    "ParameterValue": "None"
   },
   {
     "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",

--- a/configuration/di-authentication-integration/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-integration/frontend-pipeline/parameters.json
@@ -41,7 +41,7 @@
   },
   {
     "ParameterKey": "ECSCanaryDeployment",
-    "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
+    "ParameterValue": "None"
   },
   {
     "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",

--- a/configuration/di-authentication-production/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-production/frontend-pipeline/parameters.json
@@ -41,7 +41,7 @@
   },
   {
     "ParameterKey": "ECSCanaryDeployment",
-    "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
+    "ParameterValue": "None"
   },
   {
     "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",


### PR DESCRIPTION
## What

Disable frontend ECS Blue/green deployment
Issue: [AUT-3990]

## How to review

Env level configuration. Can only be tested on the target env. 
Deploy pipeline changes to the target environment `./provision-<environment>.sh -p`, delete frontend stack and redeploy. 

[AUT-3990]: https://govukverify.atlassian.net/browse/AUT-3990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ