### PR TITLE
AUT-3693: Move integration pipeline alerts to dev channel

### DIFF
--- a/configuration/di-authentication-integration/build-notifications/parameters.json
+++ b/configuration/di-authentication-integration/build-notifications/parameters.json
@@ -5,10 +5,10 @@
   },
   {
     "ParameterKey": "SlackChannelId",
-    "ParameterValue": "C07TMK4CGH2"
+    "ParameterValue": "C02KUCT0ZAS"
   },
   {
     "ParameterKey": "EnrichedNotifications",
-    "ParameterValue": "False"
+    "ParameterValue": "True"
   }
 ]


### PR DESCRIPTION
## What

Moving integration frontend pipeline notifications to the `#di-auth-developers` channel, where the Authentication team members monitor any deployment failures.

## How to review

Step 1.17 of migration https://govukverify.atlassian.net/wiki/spaces/LO/pages/4773052525/Auth+New+Frontend+Go-live+Release+Plan