### PR TITLE
AUT-4049: Sync DNS firewall allowlisting with old accounts

### DIFF
--- a/configuration/di-authentication-build/vpc/parameters.json
+++ b/configuration/di-authentication-build/vpc/parameters.json
@@ -1,7 +1,7 @@
 [
   {
     "ParameterKey": "AllowedDomains",
-    "ParameterValue": "*.account.gov.uk"
+    "ParameterValue": " *.build.account.gov.uk.,*.govuk.digital.,*.stubs.account.gov.uk.,account-api.integration.publishing.service.gov.uk.,api.experianaperture.io.,api.notifications.service.gov.uk.,d2kjg78kcam6ku.cloudfront.net.,de2ghtit0q15h.cloudfront.net.,govuk.zendesk.com.,metadata.google.internal.,noksyhw.x.incapdns.net."
   },
   {
     "ParameterKey": "CidrBlock",

--- a/configuration/di-authentication-integration/vpc/parameters.json
+++ b/configuration/di-authentication-integration/vpc/parameters.json
@@ -1,7 +1,7 @@
 [
   {
     "ParameterKey": "AllowedDomains",
-    "ParameterValue": "*.account.gov.uk"
+    "ParameterValue": "*.integration.account.gov.uk,*.govuk.digital.,*.stubs.account.gov.uk.,account-api.integration.publishing.service.gov.uk.,api.experianaperture.io.,api.notifications.service.gov.uk.,d2kjg78kcam6ku.cloudfront.net.,de2ghtit0q15h.cloudfront.net.,govuk.zendesk.com.,metadata.google.internal.,noksyhw.x.incapdns.net."
   },
   {
     "ParameterKey": "CidrBlock",

--- a/configuration/di-authentication-production/vpc/parameters.json
+++ b/configuration/di-authentication-production/vpc/parameters.json
@@ -1,7 +1,7 @@
 [
   {
     "ParameterKey": "AllowedDomains",
-    "ParameterValue": "*.account.gov.uk"
+    "ParameterValue": "*.account.gov.uk,*.govuk.digital.,*.stubs.account.gov.uk.,account-api.publishing.service.gov.uk.,api.experianaperture.io.,api.notifications.service.gov.uk.,d2kjg78kcam6ku.cloudfront.net.,d2xewdefz31nxh.cloudfront.net.,govuk.zendesk.com.,metadata.google.internal.,noksyhw.x.incapdns.net."
   },
   {
     "ParameterKey": "CidrBlock",

--- a/configuration/di-authentication-staging/vpc/parameters.json
+++ b/configuration/di-authentication-staging/vpc/parameters.json
@@ -1,7 +1,7 @@
 [
   {
     "ParameterKey": "AllowedDomains",
-    "ParameterValue": "*.account.gov.uk"
+    "ParameterValue": "*.staging.account.gov.uk,*.govuk.digital.,*.stubs.account.gov.uk.,account-api.staging.publishing.service.gov.uk.,api.experianaperture.io.,api.notifications.service.gov.uk.,d2kjg78kcam6ku.cloudfront.net.,de2ghtit0q15h.cloudfront.net.,govuk.zendesk.com.,metadata.google.internal.,noksyhw.x.incapdns.net."
   },
   {
     "ParameterKey": "CidrBlock",


### PR DESCRIPTION
## What

Sync DNS firewall allowlisting with old accounts
Issue: [AUT-4049]

## How to review

Compare side-by-side with Allow-list domains configuration in old accounts


[AUT-4049]: https://govukverify.atlassian.net/browse/AUT-4049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ