### PR TITLE
AUT-3694: switch pipeline and cache hit alerts to live channels

### DIFF
--- a/configuration/di-authentication-production/auth-fe-cloudfront-notification/parameters.json
+++ b/configuration/di-authentication-production/auth-fe-cloudfront-notification/parameters.json
@@ -5,6 +5,6 @@
   },
   {
     "ParameterKey": "SlackChannelId",
-    "ParameterValue": "C07VBLHANTU"
+    "ParameterValue": "C02HCLREVV5"
   }
 ]

--- a/configuration/di-authentication-production/build-notifications/parameters.json
+++ b/configuration/di-authentication-production/build-notifications/parameters.json
@@ -5,10 +5,10 @@
   },
   {
     "ParameterKey": "SlackChannelId",
-    "ParameterValue": "C07TMK4CGH2"
+    "ParameterValue": "C02KUCT0ZAS"
   },
   {
     "ParameterKey": "EnrichedNotifications",
-    "ParameterValue": "False"
+    "ParameterValue": "True"
   }
 ]


### PR DESCRIPTION
## What

Switch pipeline and cache hit alerts to live channels
Issue: [AUT-3694]

## How to review

Following step 4.3 in the [release plan](https://govukverify.atlassian.net/wiki/spaces/LO/pages/4773052525/Auth+New+Frontend+Go-live+Release+Plan)

[AUT-3694]: https://govukverify.atlassian.net/browse/AUT-3694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ