### PR TITLE
AUT-3689: refactor helper scripts to read aws_region from env

### DIFF
--- a/provision-cloudfront.sh
+++ b/provision-cloudfront.sh
@@ -81,6 +81,7 @@ STACK_PREFIX_UNDERSCORE=$(echo "${STACK_PREFIX}" | tr "-" "_")
 
 export AWS_ACCOUNT="di-authentication-${ENVIRONMENT}"
 export AWS_PROFILE="di-authentication-${ENVIRONMENT}-AWSAdministratorAccess"
+export SKIP_AWS_AUTHENTICATION="${SKIP_AWS_AUTHENTICATION:-true}"
 export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-false}"
 aws sso login --profile "${AWS_PROFILE}"
 

--- a/scripts/read_cloudformation_stack_outputs.sh
+++ b/scripts/read_cloudformation_stack_outputs.sh
@@ -7,8 +7,7 @@ set -euo pipefail
 }
 
 STACK_NAME="${1}"
-configured_region="$(aws configure get region 2> /dev/null || true)"
-REGION="${configured_region:-eu-west-2}"
+REGION="${AWS_REGION:-eu-west-2}"
 
 function get_stack_outputs {
 

--- a/scripts/read_parameters.sh
+++ b/scripts/read_parameters.sh
@@ -7,8 +7,7 @@ set -euo pipefail
 }
 
 ENVIRONMENT="${1}"
-configured_region="$(aws configure get region 2> /dev/null || true)"
-REGION="${configured_region:-eu-west-2}"
+REGION="${AWS_REGION:-eu-west-2}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
   ENVIRONMENT="build"

--- a/scripts/read_secrets.sh
+++ b/scripts/read_secrets.sh
@@ -7,8 +7,7 @@ set -euo pipefail
 }
 
 ENVIRONMENT="${1}"
-configured_region="$(aws configure get region 2> /dev/null || true)"
-REGION="${configured_region:-eu-west-2}"
+REGION="${AWS_REGION:-eu-west-2}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
   ENVIRONMENT="build"


### PR DESCRIPTION
## What

Refactor helper scripts to read aws_region from env
Issue: [AUT-3689]

## How to review

Run `./provision-cloudfront.sh` with a CloudFront distribution change i.e. `./provision-cloudfront.sh -e build -d live`

[AUT-3689]: https://govukverify.atlassian.net/browse/AUT-3689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ