### PR TITLE
AUT-4067: Upgrade vpc stack with vpc peering configurations

### DIFF
--- a/configuration/di-authentication-build/vpc/parameters.json
+++ b/configuration/di-authentication-build/vpc/parameters.json
@@ -70,5 +70,13 @@
   {
     "ParameterKey": "SecretsManagerApiEnabled",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "VpcPeeringConnectionId",
+    "ParameterValue": "pcx-0b7ffc78f2c186b74"
+  },
+  {
+    "ParameterKey": "VpcPeeringRequesterCidr",
+    "ParameterValue": "10.0.0.0/15"
   }
 ]

--- a/configuration/di-authentication-development/vpc/parameters.json
+++ b/configuration/di-authentication-development/vpc/parameters.json
@@ -70,5 +70,13 @@
   {
     "ParameterKey": "SecretsManagerApiEnabled",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "VpcPeeringConnectionId",
+    "ParameterValue": "pcx-0bd64e7650672b45e"
+  },
+  {
+    "ParameterKey": "VpcPeeringRequesterCidr",
+    "ParameterValue": "10.0.0.0/16"
   }
 ]

--- a/configuration/di-authentication-integration/vpc/parameters.json
+++ b/configuration/di-authentication-integration/vpc/parameters.json
@@ -70,5 +70,13 @@
   {
     "ParameterKey": "SecretsManagerApiEnabled",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "VpcPeeringConnectionId",
+    "ParameterValue": "pcx-03e4d197dd7f63a9e"
+  },
+  {
+    "ParameterKey": "VpcPeeringRequesterCidr",
+    "ParameterValue": "10.0.0.0/15"
   }
 ]

--- a/configuration/di-authentication-production/vpc/parameters.json
+++ b/configuration/di-authentication-production/vpc/parameters.json
@@ -70,5 +70,13 @@
   {
     "ParameterKey": "SecretsManagerApiEnabled",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "VpcPeeringConnectionId",
+    "ParameterValue": "pcx-00e453a07efbdf22a"
+  },
+  {
+    "ParameterKey": "VpcPeeringRequesterCidr",
+    "ParameterValue": "10.0.0.0/15"
   }
 ]

--- a/configuration/di-authentication-staging/vpc/parameters.json
+++ b/configuration/di-authentication-staging/vpc/parameters.json
@@ -70,5 +70,13 @@
   {
     "ParameterKey": "SecretsManagerApiEnabled",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "VpcPeeringConnectionId",
+    "ParameterValue": "pcx-0cee0f913125fa9b2"
+  },
+  {
+    "ParameterKey": "VpcPeeringRequesterCidr",
+    "ParameterValue": "10.0.0.0/15"
   }
 ]

--- a/provision-build.sh
+++ b/provision-build.sh
@@ -116,7 +116,7 @@ function provision_base_stacks {
 function provision_vpc {
   export AWS_REGION="eu-west-2"
 
-  VPC_TEMPLATE_VERSION="v2.7.0"
+  VPC_TEMPLATE_VERSION="v2.9.0"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 

--- a/provision-build.sh
+++ b/provision-build.sh
@@ -9,11 +9,12 @@ function usage {
   Script to bootstrap di-authentication-build account
 
   Usage:
-    $0 [-b|--base-stacks] [-p|--pipelines] [-l|--live-zone-resources <zone-only|all>]
+    $0 [-b|--base-stacks] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
 
   Options:
     -b, --base-stacks                      Provision base stacks
     -p, --pipelines                        Provision secure pipelines
+    -v, --vpc                              Provision VPC stack
     -l, --live-zone-resources              Provision live hosted zone, certificates and SSM params
 USAGE
 }
@@ -26,6 +27,7 @@ fi
 PROVISION_BASE_STACKS=false
 PROVISION_PIPELINES=false
 PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=false
+PROVISION_VPC=false
 
 while [[ $# -gt 0 ]]; do
   case "${1}" in
@@ -34,6 +36,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     -p | --pipelines)
       PROVISION_PIPELINES=true
+      ;;
+    -v | --vpc)
+      PROVISION_VPC=true
       ;;
     -l | --live-zone-resources)
       PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=true
@@ -98,14 +103,21 @@ function provision_base_stacks {
   ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
   ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
 
-  VPC_TEMPLATE_VERSION="v2.7.0"
-  ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
-
   CONTAINER_IMAGE_TEMPLATE_VERSION="v2.0.1"
   ./provisioner.sh "${AWS_ACCOUNT}" frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
   ./provisioner.sh "${AWS_ACCOUNT}" service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
 
   ./provisioner.sh "${AWS_ACCOUNT}" acceptance-tests-image-repository test-image-repository v1.2.0
+}
+
+# -------------------
+# provision vpc stack
+# -------------------
+function provision_vpc {
+  export AWS_REGION="eu-west-2"
+
+  VPC_TEMPLATE_VERSION="v2.7.0"
+  ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 
 # -------------------
@@ -180,3 +192,4 @@ function provision_live_hosted_zone_and_records {
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
 [ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_live_hosted_zone_and_records
+[ "${PROVISION_VPC}" == "true" ] && provision_vpc

--- a/provision-dev.sh
+++ b/provision-dev.sh
@@ -9,11 +9,12 @@ function usage {
   Script to bootstrap di-authentication-development account
 
   Usage:
-    $0 [-b|--base-stacks] [-p|--pipelines] [-z|--hosted-zone-resources]
+    $0 [-b|--base-stacks] [-p|--pipelines] [-v|--vpc] [-z|--hosted-zone-resources]
 
   Options:
     -b, --base-stacks                      Provision base stacks
     -p, --pipelines                        Provision secure pipelines
+    -v, --vpc                              Provision VPC stack
     -z, --hosted-zone-resources            Provision hosted zone, certificates and SSM params
 USAGE
 }
@@ -26,6 +27,7 @@ fi
 PROVISION_BASE_STACKS=false
 PROVISION_PIPELINES=false
 PROVISION_HOSTED_ZONE_AND_RECORDS=false
+PROVISION_VPC=false
 
 while [[ $# -gt 0 ]]; do
   case "${1}" in
@@ -34,6 +36,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     -p | --pipelines)
       PROVISION_PIPELINES=true
+      ;;
+    -v | --vpc)
+      PROVISION_VPC=true
       ;;
     -z | --hosted-zone-resources)
       PROVISION_HOSTED_ZONE_AND_RECORDS=true
@@ -78,9 +83,6 @@ function provision_base_stacks {
   ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
   ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
 
-  VPC_TEMPLATE_VERSION="v2.7.0"
-  ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
-
   ./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.3
 
   CONTAINER_IMAGE_TEMPLATE_VERSION="v2.0.1"
@@ -95,6 +97,16 @@ function provision_base_stacks {
   # NOTE: tag immutability is manually disabled for these ecr repositories
   ./provisioner.sh "${AWS_ACCOUNT}" authdev2-frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
   ./provisioner.sh "${AWS_ACCOUNT}" authdev2-service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
+}
+
+# -------------------
+# provision vpc stack
+# -------------------
+function provision_vpc {
+  export AWS_REGION="eu-west-2"
+
+  VPC_TEMPLATE_VERSION="v2.7.0"
+  ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 
 # -------------------
@@ -213,3 +225,4 @@ function provision_hosted_zone_and_records {
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
 [ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_hosted_zone_and_records
+[ "${PROVISION_VPC}" == "true" ] && provision_vpc

--- a/provision-dev.sh
+++ b/provision-dev.sh
@@ -105,7 +105,7 @@ function provision_base_stacks {
 function provision_vpc {
   export AWS_REGION="eu-west-2"
 
-  VPC_TEMPLATE_VERSION="v2.7.0"
+  VPC_TEMPLATE_VERSION="v2.9.0"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 

--- a/provision-integration.sh
+++ b/provision-integration.sh
@@ -116,7 +116,7 @@ function provision_base_stacks {
 function provision_vpc {
   export AWS_REGION="eu-west-2"
 
-  VPC_TEMPLATE_VERSION="v2.7.0"
+  VPC_TEMPLATE_VERSION="v2.9.0"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 

--- a/provision-production.sh
+++ b/provision-production.sh
@@ -116,7 +116,7 @@ function provision_base_stacks {
 function provision_vpc {
   export AWS_REGION="eu-west-2"
 
-  VPC_TEMPLATE_VERSION="v2.7.0"
+  VPC_TEMPLATE_VERSION="v2.9.0"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 

--- a/provision-production.sh
+++ b/provision-production.sh
@@ -9,11 +9,12 @@ function usage {
   Script to bootstrap di-authentication-production account
 
   Usage:
-    $0 [-b|--base-stacks] [-p|--pipelines] [-l|--live-zone-resources <zone-only|all>]
+    $0 [-b|--base-stacks] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
 
   Options:
     -b, --base-stacks                      Provision base stacks
     -p, --pipelines                        Provision secure pipelines
+    -v, --vpc                              Provision VPC stack
     -t, --transitional-zone-resources      Provision transitional hosted zone, certificates and SSM params
     -l, --live-zone-resources              Provision live hosted zone, certificates and SSM params
 USAGE
@@ -27,6 +28,7 @@ fi
 PROVISION_BASE_STACKS=false
 PROVISION_PIPELINES=false
 PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=false
+PROVISION_VPC=false
 
 while [[ $# -gt 0 ]]; do
   case "${1}" in
@@ -35,6 +37,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     -p | --pipelines)
       PROVISION_PIPELINES=true
+      ;;
+    -v | --vpc)
+      PROVISION_VPC=true
       ;;
     -l | --live-zone-resources)
       PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=true
@@ -102,10 +107,17 @@ function provision_base_stacks {
   ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
   ./provisioner.sh "${AWS_ACCOUNT}" build-notifications build-notifications v2.3.3
 
+  TEMPLATE_BUCKET="backup-template-storage-templatebucket-747f3bzunrod" ./provisioner.sh "${AWS_ACCOUNT}" backup-monitoring backup-vault-monitoring LATEST
+}
+
+# -------------------
+# provision vpc stack
+# -------------------
+function provision_vpc {
+  export AWS_REGION="eu-west-2"
+
   VPC_TEMPLATE_VERSION="v2.7.0"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
-
-  TEMPLATE_BUCKET="backup-template-storage-templatebucket-747f3bzunrod" ./provisioner.sh "${AWS_ACCOUNT}" backup-monitoring backup-vault-monitoring LATEST
 }
 
 # -------------------
@@ -157,3 +169,4 @@ function provision_live_hosted_zone_and_records {
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
 [ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_live_hosted_zone_and_records
+[ "${PROVISION_VPC}" == "true" ] && provision_vpc

--- a/provision-staging.sh
+++ b/provision-staging.sh
@@ -9,11 +9,12 @@ function usage {
   Script to bootstrap di-authentication-staging account
 
   Usage:
-    $0 [-b|--base-stacks] [-p|--pipelines] [-l|--live-zone-resources <zone-only|all>]
+    $0 [-b|--base-stacks] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
 
   Options:
     -b, --base-stacks                      Provision base stacks
     -p, --pipelines                        Provision secure pipelines
+    -v, --vpc                              Provision VPC stack
     -t, --transitional-zone-resources      Provision transitional hosted zone, certificates and SSM params
     -l, --live-zone-resources              Provision live hosted zone, certificates and SSM params
 USAGE
@@ -27,6 +28,7 @@ fi
 PROVISION_BASE_STACKS=false
 PROVISION_PIPELINES=false
 PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=false
+PROVISION_VPC=false
 
 while [[ $# -gt 0 ]]; do
   case "${1}" in
@@ -35,6 +37,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     -p | --pipelines)
       PROVISION_PIPELINES=true
+      ;;
+    -v | --vpc)
+      PROVISION_VPC=true
       ;;
     -l | --live-zone-resources)
       PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=true
@@ -109,9 +114,17 @@ function provision_base_stacks {
   ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
   ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
 
+  TEMPLATE_BUCKET="backup-template-storage-templatebucket-747f3bzunrod" ./provisioner.sh "${AWS_ACCOUNT}" backup-monitoring backup-vault-monitoring LATEST
+}
+
+# -------------------
+# provision vpc stack
+# -------------------
+function provision_vpc {
+  export AWS_REGION="eu-west-2"
+
   VPC_TEMPLATE_VERSION="v2.7.0"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
-  TEMPLATE_BUCKET="backup-template-storage-templatebucket-747f3bzunrod" ./provisioner.sh "${AWS_ACCOUNT}" backup-monitoring backup-vault-monitoring LATEST
 }
 
 # -------------------
@@ -178,3 +191,4 @@ function provision_live_hosted_zone_and_records {
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
 [ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_live_hosted_zone_and_records
+[ "${PROVISION_VPC}" == "true" ] && provision_vpc


### PR DESCRIPTION
## What

Upgrade vpc stack with vpc peering configurations

Issue: [AUT-4067]

## How to review

Slack thread with relevant discussion https://gds.slack.com/archives/C082N2A586R/p1742564802498929

### Problem statement
no mechanism to import an existing route table entry in an existing route table managed by cloudformation :clown_face:. Simply trying to add one will return an "AlreadyExists" error.

### Proposed solution: 
SRE :zero: -downtime add -> remove - modify
Step 1. Add: via Cloudformation, add a /15 catch-all cidr range
Step 2. Remove: existing /16 entry that was manually added before
Step 3. Change: update /15 to /16

This PR is **step 1 of 3.** 

[AUT-4067]: https://govukverify.atlassian.net/browse/AUT-4067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ