### PR TITLE
AUT-4067: Bump vpc stack in staging to v2.9.0

### DIFF
--- a/provision-staging.sh
+++ b/provision-staging.sh
@@ -123,7 +123,7 @@ function provision_base_stacks {
 function provision_vpc {
   export AWS_REGION="eu-west-2"
 
-  VPC_TEMPLATE_VERSION="v2.7.0"
+  VPC_TEMPLATE_VERSION="v2.9.0"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 


### PR DESCRIPTION
## What

Bump vpc stack in staging to v2.9.0
Issue: [AUT-4067]

## How to review

Meant to be part of https://github.com/govuk-one-login/authentication-infrastructure/pull/62


[AUT-4067]: https://govukverify.atlassian.net/browse/AUT-4067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ