### PR TITLE
AUT-4238:  Notification stack to integrate with CloudWatch alarms

### DIFF
--- a/alerts/template.yaml
+++ b/alerts/template.yaml
@@ -5,12 +5,15 @@ Description: >
   Authentication alerts SNS topic, enricher function and slack integration
 
 Parameters:
-  AccountAlias:
-    Description: >
-      Account alias of the AWS account where this stack is deployed. This
-      information is passed onto slack notification
+  Environment:
     Type: String
-    Default: ""
+    Description: The name of the environment to deploy to
+    AllowedValues:
+      - build
+      - staging
+      - production
+      - integration
+      - dev
 
   SlackWorkspaceId:
     Description: >
@@ -35,6 +38,19 @@ Outputs:
     Value: !Ref NotificationTopic
     Export:
       Name: !Sub "${AWS::StackName}-NotificationTopicArn"
+
+Mappings:
+  EnvironmentConfiguration:
+    dev:
+      AccountAlias: "di-authentication-development"
+    build:
+      AccountAlias: "di-authentication-build"
+    staging:
+      AccountAlias: "di-authentication-staging"
+    integration:
+      AccountAlias: "di-authentication-integration"
+    production:
+      AccountAlias: "di-authentication-production"
 
 Resources:
   NotificationTopic:
@@ -68,6 +84,17 @@ Resources:
             Principal:
               Service:
                 - cloudwatch.amazonaws.com
+
+  NotificationTopicSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: "The ARN of the SNS topic that receives CloudWatch notifications"
+      Name: !Sub "/deploy/${Environment}/notification_topic_arn"
+      Type: String
+      Value: !Ref NotificationTopic
+      Tags:
+        Application: "Authentication"
+        Source: govuk-one-login/authentication-infrastructure/alerts/template.yaml
 
   LambdaExecutionRole:
     Type: AWS::IAM::Role
@@ -113,7 +140,12 @@ Resources:
       CodeUri: src
       Environment:
         Variables:
-          ACCOUNT_ALIAS: !Ref AccountAlias
+          ACCOUNT_ALIAS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              AccountAlias,
+            ]
           NOTIFICATION_DETAILED_TOPIC_ARN: !Ref NotificationDetailedTopic
 
   NotificationEnricherFunctionInvokePermission:

--- a/configuration/di-authentication-build/auth-fe-cloudfront-notification/parameters.json
+++ b/configuration/di-authentication-build/auth-fe-cloudfront-notification/parameters.json
@@ -1,5 +1,9 @@
 [
   {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
     "ParameterKey": "SlackWorkspaceId",
     "ParameterValue": "T8GT9416G"
   },

--- a/configuration/di-authentication-build/cloudwatch-alarm-notification/parameters.json
+++ b/configuration/di-authentication-build/cloudwatch-alarm-notification/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "build"
+  },
+  {
+    "ParameterKey": "SlackWorkspaceId",
+    "ParameterValue": "T8GT9416G"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C08MW7X7HEY"
+  }
+]

--- a/configuration/di-authentication-development/auth-fe-cloudfront-notification/parameters.json
+++ b/configuration/di-authentication-development/auth-fe-cloudfront-notification/parameters.json
@@ -1,5 +1,9 @@
 [
   {
+    "ParameterKey": "Environment",
+    "ParameterValue": "dev"
+  },
+  {
     "ParameterKey": "SlackWorkspaceId",
     "ParameterValue": "T8GT9416G"
   },

--- a/configuration/di-authentication-development/cloudwatch-alarm-notification/parameters.json
+++ b/configuration/di-authentication-development/cloudwatch-alarm-notification/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "SlackWorkspaceId",
+    "ParameterValue": "T8GT9416G"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C08MW7X7HEY"
+  }
+]

--- a/configuration/di-authentication-integration/auth-fe-cloudfront-notification/parameters.json
+++ b/configuration/di-authentication-integration/auth-fe-cloudfront-notification/parameters.json
@@ -1,5 +1,9 @@
 [
   {
+    "ParameterKey": "Environment",
+    "ParameterValue": "integration"
+  },
+  {
     "ParameterKey": "SlackWorkspaceId",
     "ParameterValue": "T8GT9416G"
   },

--- a/configuration/di-authentication-integration/cloudwatch-alarm-notification/parameters.json
+++ b/configuration/di-authentication-integration/cloudwatch-alarm-notification/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "integration"
+  },
+  {
+    "ParameterKey": "SlackWorkspaceId",
+    "ParameterValue": "T8GT9416G"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C08MW7X7HEY"
+  }
+]

--- a/configuration/di-authentication-production/auth-fe-cloudfront-notification/parameters.json
+++ b/configuration/di-authentication-production/auth-fe-cloudfront-notification/parameters.json
@@ -1,5 +1,9 @@
 [
   {
+    "ParameterKey": "Environment",
+    "ParameterValue": "production"
+  },
+  {
     "ParameterKey": "SlackWorkspaceId",
     "ParameterValue": "T8GT9416G"
   },

--- a/configuration/di-authentication-production/cloudwatch-alarm-notification/parameters.json
+++ b/configuration/di-authentication-production/cloudwatch-alarm-notification/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "production"
+  },
+  {
+    "ParameterKey": "SlackWorkspaceId",
+    "ParameterValue": "T8GT9416G"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C08MW7X7HEY"
+  }
+]

--- a/configuration/di-authentication-staging/auth-fe-cloudfront-notification/parameters.json
+++ b/configuration/di-authentication-staging/auth-fe-cloudfront-notification/parameters.json
@@ -1,5 +1,9 @@
 [
   {
+    "ParameterKey": "Environment",
+    "ParameterValue": "staging"
+  },
+  {
     "ParameterKey": "SlackWorkspaceId",
     "ParameterValue": "T8GT9416G"
   },

--- a/configuration/di-authentication-staging/cloudwatch-alarm-notification/parameters.json
+++ b/configuration/di-authentication-staging/cloudwatch-alarm-notification/parameters.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "staging"
+  },
+  {
+    "ParameterKey": "SlackWorkspaceId",
+    "ParameterValue": "T8GT9416G"
+  },
+  {
+    "ParameterKey": "SlackChannelId",
+    "ParameterValue": "C08MW7X7HEY"
+  }
+]

--- a/provision-build.sh
+++ b/provision-build.sh
@@ -9,10 +9,11 @@ function usage {
   Script to bootstrap di-authentication-build account
 
   Usage:
-    $0 [-b|--base-stacks] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
+    $0 [-b|--base-stacks] [-n|--notification] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
 
   Options:
     -b, --base-stacks                      Provision base stacks
+    -n, --notification                     Creates a SNS topic with Slack integration
     -p, --pipelines                        Provision secure pipelines
     -v, --vpc                              Provision VPC stack
     -l, --live-zone-resources              Provision live hosted zone, certificates and SSM params
@@ -25,14 +26,18 @@ if [ $# -lt 1 ]; then
 fi
 
 PROVISION_BASE_STACKS=false
-PROVISION_PIPELINES=false
 PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=false
+PROVISION_NOTIFICATION_STACK=false
+PROVISION_PIPELINES=false
 PROVISION_VPC=false
 
 while [[ $# -gt 0 ]]; do
   case "${1}" in
     -b | --base-stacks)
       PROVISION_BASE_STACKS=true
+      ;;
+    -n | --notification)
+      PROVISION_NOTIFICATION_STACK=true
       ;;
     -p | --pipelines)
       PROVISION_PIPELINES=true
@@ -198,10 +203,40 @@ function provision_live_hosted_zone_and_records {
   PARAMETERS_FILE=$PARAMETERS_FILE TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" hosted-zones-and-records dns LATEST
 }
 
+# --------------------------------------------
+#   Creates a SNS topic with slack integration
+# --------------------------------------------
+function provision_notification {
+  SAM_PARAMETERS=$(jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"' "configuration/${AWS_ACCOUNT}/cloudwatch-alarm-notification/parameters.json")
+  TAGS=$(jq -r '.[] | "\(.Key)=\(.Value)" | gsub(" ";"-")' "configuration/${AWS_ACCOUNT}/tags.json")
+
+  CONFIRM_CHANGESET_OPTION="--confirm-changeset"
+  if [ "${AUTO_APPLY_CHANGESET}" == "true" ]; then
+    CONFIRM_CHANGESET_OPTION="--no-confirm-changeset"
+  fi
+
+  export AWS_REGION="eu-west-2"
+  pushd alerts
+  sam build
+  # shellcheck disable=SC2086
+  sam deploy \
+    --stack-name "cloudwatch-alarm-notification" \
+    --resolve-s3 true \
+    --s3-prefix "cloudwatch-alarm-notification" \
+    --region "eu-west-2" \
+    --capabilities "CAPABILITY_IAM" \
+    $CONFIRM_CHANGESET_OPTION \
+    --no-fail-on-empty-changeset \
+    --parameter-overrides $SAM_PARAMETERS \
+    --tags $TAGS
+  popd
+}
+
 # --------------------
 # Provision components
 # --------------------
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
-[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_live_hosted_zone_and_records
+[ "${PROVISION_NOTIFICATION_STACK}" == "true" ] && provision_notification
+[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_VPC}" == "true" ] && provision_vpc

--- a/provision-cloudfront.sh
+++ b/provision-cloudfront.sh
@@ -207,11 +207,7 @@ function provision_distribution {
 #   no dependency
 # -----------------------------------------------------------------------------------
 function provision_notification {
-  PARAMETERS_FILE="configuration/${AWS_ACCOUNT}/${STACK_PREFIX}-cloudfront-notification/parameters.json"
-  PARAMETERS=$(jq ". += [
-                            {\"ParameterKey\":\"AccountAlias\",\"ParameterValue\":\"${AWS_ACCOUNT}\"}
-                        ] | tojson" -r "${PARAMETERS_FILE}")
-  SAM_PARAMETERS=$(echo "$PARAMETERS" | jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"')
+  SAM_PARAMETERS=$(jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"' "configuration/${AWS_ACCOUNT}/${STACK_PREFIX}-cloudfront-notification/parameters.json")
   TAGS=$(jq -r '.[] | "\(.Key)=\(.Value)" | gsub(" ";"-")' "configuration/${AWS_ACCOUNT}/tags.json")
 
   CONFIRM_CHANGESET_OPTION="--confirm-changeset"

--- a/provision-integration.sh
+++ b/provision-integration.sh
@@ -9,13 +9,13 @@ function usage {
   Script to bootstrap di-authentication-integration account
 
   Usage:
-    $0 [-b|--base-stacks] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
+    $0 [-b|--base-stacks] [-n|--notification] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
 
   Options:
     -b, --base-stacks                      Provision base stacks
+    -n, --notification                     Creates a SNS topic with Slack integration
     -p, --pipelines                        Provision secure pipelines
     -v, --vpc                              Provision VPC stack
-    -t, --transitional-zone-resources      Provision transitional hosted zone, certificates and SSM params
     -l, --live-zone-resources              Provision live hosted zone, certificates and SSM params
 USAGE
 }
@@ -26,14 +26,18 @@ if [ $# -lt 1 ]; then
 fi
 
 PROVISION_BASE_STACKS=false
-PROVISION_PIPELINES=false
 PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=false
+PROVISION_NOTIFICATION_STACK=false
+PROVISION_PIPELINES=false
 PROVISION_VPC=false
 
 while [[ $# -gt 0 ]]; do
   case "${1}" in
     -b | --base-stacks)
       PROVISION_BASE_STACKS=true
+      ;;
+    -n | --notification)
+      PROVISION_NOTIFICATION_STACK=true
       ;;
     -p | --pipelines)
       PROVISION_PIPELINES=true
@@ -163,10 +167,40 @@ function provision_live_hosted_zone_and_records {
   PARAMETERS_FILE=$PARAMETERS_FILE TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" hosted-zones-and-records dns LATEST
 }
 
+# --------------------------------------------
+#   Creates a SNS topic with slack integration
+# --------------------------------------------
+function provision_notification {
+  SAM_PARAMETERS=$(jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"' "configuration/${AWS_ACCOUNT}/cloudwatch-alarm-notification/parameters.json")
+  TAGS=$(jq -r '.[] | "\(.Key)=\(.Value)" | gsub(" ";"-")' "configuration/${AWS_ACCOUNT}/tags.json")
+
+  CONFIRM_CHANGESET_OPTION="--confirm-changeset"
+  if [ "${AUTO_APPLY_CHANGESET}" == "true" ]; then
+    CONFIRM_CHANGESET_OPTION="--no-confirm-changeset"
+  fi
+
+  export AWS_REGION="eu-west-2"
+  pushd alerts
+  sam build
+  # shellcheck disable=SC2086
+  sam deploy \
+    --stack-name "cloudwatch-alarm-notification" \
+    --resolve-s3 true \
+    --s3-prefix "cloudwatch-alarm-notification" \
+    --region "eu-west-2" \
+    --capabilities "CAPABILITY_IAM" \
+    $CONFIRM_CHANGESET_OPTION \
+    --no-fail-on-empty-changeset \
+    --parameter-overrides $SAM_PARAMETERS \
+    --tags $TAGS
+  popd
+}
+
 # --------------------
 # Provision components
 # --------------------
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
-[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_live_hosted_zone_and_records
+[ "${PROVISION_NOTIFICATION_STACK}" == "true" ] && provision_notification
+[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_VPC}" == "true" ] && provision_vpc

--- a/provision-production.sh
+++ b/provision-production.sh
@@ -9,13 +9,13 @@ function usage {
   Script to bootstrap di-authentication-production account
 
   Usage:
-    $0 [-b|--base-stacks] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
+    $0 [-b|--base-stacks] [-n|--notification] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
 
   Options:
     -b, --base-stacks                      Provision base stacks
+    -n, --notification                     Creates a SNS topic with Slack integration
     -p, --pipelines                        Provision secure pipelines
     -v, --vpc                              Provision VPC stack
-    -t, --transitional-zone-resources      Provision transitional hosted zone, certificates and SSM params
     -l, --live-zone-resources              Provision live hosted zone, certificates and SSM params
 USAGE
 }
@@ -26,14 +26,18 @@ if [ $# -lt 1 ]; then
 fi
 
 PROVISION_BASE_STACKS=false
-PROVISION_PIPELINES=false
 PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=false
+PROVISION_NOTIFICATION_STACK=false
+PROVISION_PIPELINES=false
 PROVISION_VPC=false
 
 while [[ $# -gt 0 ]]; do
   case "${1}" in
     -b | --base-stacks)
       PROVISION_BASE_STACKS=true
+      ;;
+    -n | --notification)
+      PROVISION_NOTIFICATION_STACK=true
       ;;
     -p | --pipelines)
       PROVISION_PIPELINES=true
@@ -163,10 +167,40 @@ function provision_live_hosted_zone_and_records {
   PARAMETERS_FILE=$PARAMETERS_FILE TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" hosted-zones-and-records dns LATEST
 }
 
+# --------------------------------------------
+#   Creates a SNS topic with slack integration
+# --------------------------------------------
+function provision_notification {
+  SAM_PARAMETERS=$(jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"' "configuration/${AWS_ACCOUNT}/cloudwatch-alarm-notification/parameters.json")
+  TAGS=$(jq -r '.[] | "\(.Key)=\(.Value)" | gsub(" ";"-")' "configuration/${AWS_ACCOUNT}/tags.json")
+
+  CONFIRM_CHANGESET_OPTION="--confirm-changeset"
+  if [ "${AUTO_APPLY_CHANGESET}" == "true" ]; then
+    CONFIRM_CHANGESET_OPTION="--no-confirm-changeset"
+  fi
+
+  export AWS_REGION="eu-west-2"
+  pushd alerts
+  sam build
+  # shellcheck disable=SC2086
+  sam deploy \
+    --stack-name "cloudwatch-alarm-notification" \
+    --resolve-s3 true \
+    --s3-prefix "cloudwatch-alarm-notification" \
+    --region "eu-west-2" \
+    --capabilities "CAPABILITY_IAM" \
+    $CONFIRM_CHANGESET_OPTION \
+    --no-fail-on-empty-changeset \
+    --parameter-overrides $SAM_PARAMETERS \
+    --tags $TAGS
+  popd
+}
+
 # --------------------
 # Provision components
 # --------------------
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
-[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_live_hosted_zone_and_records
+[ "${PROVISION_NOTIFICATION_STACK}" == "true" ] && provision_notification
+[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_VPC}" == "true" ] && provision_vpc

--- a/provision-staging.sh
+++ b/provision-staging.sh
@@ -9,13 +9,13 @@ function usage {
   Script to bootstrap di-authentication-staging account
 
   Usage:
-    $0 [-b|--base-stacks] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
+    $0 [-b|--base-stacks] [-n|--notification] [-p|--pipelines] [-v|--vpc] [-l|--live-zone-resources <zone-only|all>]
 
   Options:
     -b, --base-stacks                      Provision base stacks
+    -n, --notification                     Creates a SNS topic with Slack integration
     -p, --pipelines                        Provision secure pipelines
     -v, --vpc                              Provision VPC stack
-    -t, --transitional-zone-resources      Provision transitional hosted zone, certificates and SSM params
     -l, --live-zone-resources              Provision live hosted zone, certificates and SSM params
 USAGE
 }
@@ -26,14 +26,18 @@ if [ $# -lt 1 ]; then
 fi
 
 PROVISION_BASE_STACKS=false
-PROVISION_PIPELINES=false
 PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS=false
+PROVISION_NOTIFICATION_STACK=false
+PROVISION_PIPELINES=false
 PROVISION_VPC=false
 
 while [[ $# -gt 0 ]]; do
   case "${1}" in
     -b | --base-stacks)
       PROVISION_BASE_STACKS=true
+      ;;
+    -n | --notification)
+      PROVISION_NOTIFICATION_STACK=true
       ;;
     -p | --pipelines)
       PROVISION_PIPELINES=true
@@ -185,10 +189,40 @@ function provision_live_hosted_zone_and_records {
   PARAMETERS_FILE=$PARAMETERS_FILE TEMPLATE_URL=file://authentication-frontend/cloudformation/domains/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" hosted-zones-and-records dns LATEST
 }
 
+# --------------------------------------------
+#   Creates a SNS topic with slack integration
+# --------------------------------------------
+function provision_notification {
+  SAM_PARAMETERS=$(jq -r '.[] | "\(.ParameterKey)=\(.ParameterValue)"' "configuration/${AWS_ACCOUNT}/cloudwatch-alarm-notification/parameters.json")
+  TAGS=$(jq -r '.[] | "\(.Key)=\(.Value)" | gsub(" ";"-")' "configuration/${AWS_ACCOUNT}/tags.json")
+
+  CONFIRM_CHANGESET_OPTION="--confirm-changeset"
+  if [ "${AUTO_APPLY_CHANGESET}" == "true" ]; then
+    CONFIRM_CHANGESET_OPTION="--no-confirm-changeset"
+  fi
+
+  export AWS_REGION="eu-west-2"
+  pushd alerts
+  sam build
+  # shellcheck disable=SC2086
+  sam deploy \
+    --stack-name "cloudwatch-alarm-notification" \
+    --resolve-s3 true \
+    --s3-prefix "cloudwatch-alarm-notification" \
+    --region "eu-west-2" \
+    --capabilities "CAPABILITY_IAM" \
+    $CONFIRM_CHANGESET_OPTION \
+    --no-fail-on-empty-changeset \
+    --parameter-overrides $SAM_PARAMETERS \
+    --tags $TAGS
+  popd
+}
+
 # --------------------
 # Provision components
 # --------------------
 [ "${PROVISION_BASE_STACKS}" == "true" ] && provision_base_stacks
-[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_LIVE_HOSTED_ZONE_AND_RECORDS}" == "true" ] && provision_live_hosted_zone_and_records
+[ "${PROVISION_NOTIFICATION_STACK}" == "true" ] && provision_notification
+[ "${PROVISION_PIPELINES}" == "true" ] && provision_pipeline
 [ "${PROVISION_VPC}" == "true" ] && provision_vpc


### PR DESCRIPTION
## What

Notification stack to integrate with CloudWatch alarms
Alerts stack has been refactored to take Environment as param, instead of AccountAlias.

Creates a notification stack in the eu-west-2 region. SNS topic referenced in frontend stack via SSM parameter.

## How to review

Deploy to target environment i.e. `./provision-dev.sh --notification`. 