### PR TITLE
AUT-4301: adds private subnets routes thru peering connection

### DIFF
--- a/provision-build.sh
+++ b/provision-build.sh
@@ -121,7 +121,7 @@ function provision_base_stacks {
 function provision_vpc {
   export AWS_REGION="eu-west-2"
 
-  VPC_TEMPLATE_VERSION="v2.9.0"
+  VPC_TEMPLATE_VERSION="v2.9.2"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 

--- a/provision-dev.sh
+++ b/provision-dev.sh
@@ -113,7 +113,7 @@ function provision_base_stacks {
 function provision_vpc {
   export AWS_REGION="eu-west-2"
 
-  VPC_TEMPLATE_VERSION="v2.9.0"
+  VPC_TEMPLATE_VERSION="v2.9.2"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 

--- a/provision-staging.sh
+++ b/provision-staging.sh
@@ -132,7 +132,7 @@ function provision_base_stacks {
 function provision_vpc {
   export AWS_REGION="eu-west-2"
 
-  VPC_TEMPLATE_VERSION="v2.9.0"
+  VPC_TEMPLATE_VERSION="v2.9.2"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 


### PR DESCRIPTION
## What

VPC template version bump that adds private subnets routes thru peering connection
Using a dev vpc template in dev, build and staging till a published version is available

Issue: [AUT-4301]

[AUT-4301]: https://govukverify.atlassian.net/browse/AUT-4301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ