### PR TITLE
AUT-4350: Configure ECR repo lifecycle policy to retain the latest 100 images

### DIFF
--- a/configuration/di-authentication-build/frontend-image-repository/parameters.json
+++ b/configuration/di-authentication-build/frontend-image-repository/parameters.json
@@ -2,5 +2,9 @@
   {
     "ParameterKey": "PipelineStackName",
     "ParameterValue": "frontend-pipeline"
+  },
+  {
+    "ParameterKey": "RetainedImageCount",
+    "ParameterValue": "100"
   }
 ]

--- a/configuration/di-authentication-build/service-down-page-image-repository/parameters.json
+++ b/configuration/di-authentication-build/service-down-page-image-repository/parameters.json
@@ -2,5 +2,9 @@
   {
     "ParameterKey": "PipelineStackName",
     "ParameterValue": "frontend-pipeline"
+  },
+  {
+    "ParameterKey": "RetainedImageCount",
+    "ParameterValue": "100"
   }
 ]

--- a/configuration/di-authentication-development/authdev1-frontend-image-repository/parameters.json
+++ b/configuration/di-authentication-development/authdev1-frontend-image-repository/parameters.json
@@ -2,5 +2,9 @@
   {
     "ParameterKey": "PipelineStackName",
     "ParameterValue": "authdev1-frontend-pipeline"
+  },
+  {
+    "ParameterKey": "RetainedImageCount",
+    "ParameterValue": "100"
   }
 ]

--- a/configuration/di-authentication-development/authdev1-service-down-page-image-repository/parameters.json
+++ b/configuration/di-authentication-development/authdev1-service-down-page-image-repository/parameters.json
@@ -2,5 +2,9 @@
   {
     "ParameterKey": "PipelineStackName",
     "ParameterValue": "authdev1-frontend-pipeline"
+  },
+  {
+    "ParameterKey": "RetainedImageCount",
+    "ParameterValue": "100"
   }
 ]

--- a/configuration/di-authentication-development/authdev2-frontend-image-repository/parameters.json
+++ b/configuration/di-authentication-development/authdev2-frontend-image-repository/parameters.json
@@ -2,5 +2,9 @@
   {
     "ParameterKey": "PipelineStackName",
     "ParameterValue": "authdev2-frontend-pipeline"
+  },
+  {
+    "ParameterKey": "RetainedImageCount",
+    "ParameterValue": "100"
   }
 ]

--- a/configuration/di-authentication-development/authdev2-service-down-page-image-repository/parameters.json
+++ b/configuration/di-authentication-development/authdev2-service-down-page-image-repository/parameters.json
@@ -2,5 +2,9 @@
   {
     "ParameterKey": "PipelineStackName",
     "ParameterValue": "authdev2-frontend-pipeline"
+  },
+  {
+    "ParameterKey": "RetainedImageCount",
+    "ParameterValue": "100"
   }
 ]

--- a/configuration/di-authentication-development/frontend-image-repository/parameters.json
+++ b/configuration/di-authentication-development/frontend-image-repository/parameters.json
@@ -2,5 +2,9 @@
   {
     "ParameterKey": "PipelineStackName",
     "ParameterValue": "frontend-pipeline"
+  },
+  {
+    "ParameterKey": "RetainedImageCount",
+    "ParameterValue": "100"
   }
 ]

--- a/configuration/di-authentication-development/service-down-page-image-repository/parameters.json
+++ b/configuration/di-authentication-development/service-down-page-image-repository/parameters.json
@@ -2,5 +2,9 @@
   {
     "ParameterKey": "PipelineStackName",
     "ParameterValue": "frontend-pipeline"
+  },
+  {
+    "ParameterKey": "RetainedImageCount",
+    "ParameterValue": "100"
   }
 ]

--- a/provision-build.sh
+++ b/provision-build.sh
@@ -108,7 +108,7 @@ function provision_base_stacks {
   ./provisioner.sh "${AWS_ACCOUNT}" infra-audit-hook infrastructure-audit-hook LATEST
   ./provisioner.sh "${AWS_ACCOUNT}" lambda-audit-hook lambda-audit-hook LATEST
 
-  CONTAINER_IMAGE_TEMPLATE_VERSION="v2.0.1"
+  CONTAINER_IMAGE_TEMPLATE_VERSION="v3.0.0"
   ./provisioner.sh "${AWS_ACCOUNT}" frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
   ./provisioner.sh "${AWS_ACCOUNT}" service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
 

--- a/provision-dev.sh
+++ b/provision-dev.sh
@@ -92,7 +92,7 @@ function provision_base_stacks {
 
   ./provisioner.sh "${AWS_ACCOUNT}" api-gateway-logs api-gateway-logs v1.0.5
 
-  CONTAINER_IMAGE_TEMPLATE_VERSION="v2.0.1"
+  CONTAINER_IMAGE_TEMPLATE_VERSION="v3.0.0"
   # NOTE: tag immutability is manually disabled for these ecr repositories
   ./provisioner.sh "${AWS_ACCOUNT}" frontend-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"
   ./provisioner.sh "${AWS_ACCOUNT}" service-down-page-image-repository container-image-repository "${CONTAINER_IMAGE_TEMPLATE_VERSION}"


### PR DESCRIPTION
## What

Configure ECR repo lifecycle policy to retain the latest 100 images.
In compliance with RFC0096 - https://github.com/govuk-one-login/architecture/blob/main/rfc/0096-ecr-lifecycle-policy.md

Also bumped the `container-image-repository` stack version to [v3.0.0](https://github.com/govuk-one-login/devplatform-deploy/blob/main/container-image-repository/CHANGELOG.md#v300---2025-03-18)

Issue: [AUT-4350]

## How to review

Test deployment i.e. `./provision-dev.sh --base-stacks`
Detailed test reports in the JIRA ticket

[AUT-4350]: https://govukverify.atlassian.net/browse/AUT-4350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ