### PR TITLE
AUT-4095: Bump alerts lambda runtime to node 22

### DIFF
--- a/alerts/template.yaml
+++ b/alerts/template.yaml
@@ -135,7 +135,7 @@ Resources:
       Handler: alerts.handler
       MemorySize: 128
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Timeout: 30
       CodeUri: src
       Environment:


### PR DESCRIPTION
## What

Bump alerts lambda runtime to node 22. Node 18 reached EOL. 
Issue: [AUT-4095]

## How to review/test

1. Deploy either cloudwatch-alarm-notification stack (eu-west-2) or auth-fe-cloudfront-notification (us-east-1)
2. Trigger an alarm
3. Expect notification arriving in the associated slack channel

[AUT-4095]: https://govukverify.atlassian.net/browse/AUT-4095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ