### PR TITLE
BAU: frontend-pipeline test reports format and S3 storage

### DIFF
--- a/configuration/di-authentication-development/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/frontend-pipeline/parameters.json
@@ -42,5 +42,13 @@
   {
     "ParameterKey": "IncludePromotion",
     "ParameterValue": "No"
+  },
+  {
+    "ParameterKey": "TestReportFormat",
+    "ParameterValue": "CUCUMBERJSON"
+  },
+  {
+    "ParameterKey": "StoreTestReportInS3Bucket",
+    "ParameterValue": "Yes"
   }
 ]


### PR DESCRIPTION
## What

Dev frontend-pipeline test reports format set CUCUMBERJSON
Also enabled feature to save test reports in an S3 bucket
