### PR TITLE
AUT-4533: Enable LambdaCanary10Percent5Minutes canary in api pipelines

### DIFF
--- a/configuration/di-authentication-build/authentication-api-pipeline/parameters.json
+++ b/configuration/di-authentication-build/authentication-api-pipeline/parameters.json
@@ -57,7 +57,7 @@
   },
   {
     "ParameterKey": "LambdaCanaryDeployment",
-    "ParameterValue": "AllAtOnce"
+    "ParameterValue": "CodeDeployDefault.LambdaCanary10Percent5Minutes"
   },
   {
     "ParameterKey": "AccessCrossAccountSQS",

--- a/configuration/di-authentication-development/authentication-api-pipeline/parameters.json
+++ b/configuration/di-authentication-development/authentication-api-pipeline/parameters.json
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "LambdaCanaryDeployment",
-    "ParameterValue": "AllAtOnce"
+    "ParameterValue": "CodeDeployDefault.LambdaCanary10Percent5Minutes"
   },
   {
     "ParameterKey": "AccessCrossAccountSQS",

--- a/configuration/di-authentication-staging/authentication-api-pipeline/parameters.json
+++ b/configuration/di-authentication-staging/authentication-api-pipeline/parameters.json
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "LambdaCanaryDeployment",
-    "ParameterValue": "AllAtOnce"
+    "ParameterValue": "CodeDeployDefault.LambdaCanary10Percent5Minutes"
   },
   {
     "ParameterKey": "AccessCrossAccountSQS",


### PR DESCRIPTION
## What

Enable LambdaCanary10Percent5Minutes canary in api pipelines

Issue: [AUT-4533]

## How to review

How to test:
1. Deploy pipeline update i.e. `./provision-dev.sh --pipelines`
2. deploy api via this [GitHub workflow ](https://github.com/govuk-one-login/authentication-api/actions/workflows/deploy-api-modules-sp-dev.yml)

[AUT-4533]: https://govukverify.atlassian.net/browse/AUT-4533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ