### PR TITLE
AUT-4538: Private Subnet routes through vpc peering connection

### DIFF
--- a/provision-integration.sh
+++ b/provision-integration.sh
@@ -136,7 +136,7 @@ function provision_base_stacks {
 function provision_vpc {
   export AWS_REGION="eu-west-2"
 
-  VPC_TEMPLATE_VERSION="v2.9.0"
+  VPC_TEMPLATE_VERSION="v2.9.2"
   ./provisioner.sh "${AWS_ACCOUNT}" vpc vpc "${VPC_TEMPLATE_VERSION}"
 }
 


### PR DESCRIPTION
## What

Bumping vpc template version from v2.9.0 -> v2.9.2 in integration.
Includes logic to create private Subnet routes through vpc peering connection.
This is required by lambda deployed to private subnets to have cross-account redis access
