### PR TITLE
AUT-5371: Enable FraudHeaders on authdevs env for AMCCallbackHandler

### DIFF
--- a/configuration/di-authentication-development/authdev1-cloudfront/live-parameters.json
+++ b/configuration/di-authentication-development/authdev1-cloudfront/live-parameters.json
@@ -9,7 +9,7 @@
   },
   {
     "ParameterKey": "FraudHeaderEnabled",
-    "ParameterValue": "false"
+    "ParameterValue": "true"
   },
   {
     "ParameterKey": "FraudHeadersFunctionName",

--- a/configuration/di-authentication-development/authdev2-cloudfront/live-parameters.json
+++ b/configuration/di-authentication-development/authdev2-cloudfront/live-parameters.json
@@ -9,7 +9,7 @@
   },
   {
     "ParameterKey": "FraudHeaderEnabled",
-    "ParameterValue": "false"
+    "ParameterValue": "true"
   },
   {
     "ParameterKey": "FraudHeadersFunctionName",

--- a/configuration/di-authentication-development/authdev3-cloudfront/live-parameters.json
+++ b/configuration/di-authentication-development/authdev3-cloudfront/live-parameters.json
@@ -9,7 +9,7 @@
   },
   {
     "ParameterKey": "FraudHeaderEnabled",
-    "ParameterValue": "false"
+    "ParameterValue": "true"
   },
   {
     "ParameterKey": "FraudHeadersFunctionName",

--- a/provision-cloudfront.sh
+++ b/provision-cloudfront.sh
@@ -73,7 +73,13 @@ fi
 STACK_PREFIX_UNDERSCORE=$(echo "${STACK_PREFIX}" | tr "-" "_")
 
 export AWS_ACCOUNT="di-authentication-${ENVIRONMENT}"
-export AWS_PROFILE="di-authentication-${ENVIRONMENT}-AWSAdministratorAccess"
+
+if [[ ${ENVIRONMENT} == "development" ]]; then
+  export AWS_PROFILE="di-authentication-development-AdministratorAccessPermission"
+else
+  export AWS_PROFILE="di-authentication-${ENVIRONMENT}-ApprovedAdmin"
+fi
+
 export SKIP_AWS_AUTHENTICATION="${SKIP_AWS_AUTHENTICATION:-true}"
 export AUTO_APPLY_CHANGESET="${AUTO_APPLY_CHANGESET:-false}"
 if ! aws sts get-caller-identity &> /dev/null; then


### PR DESCRIPTION
## What

AUT-5371: Enable FraudHeaders on authdevs env for AMCCallbackHandler

## How to review

1. Code Review. , This is applied to all authdevs env using 
`./provision-cloudfront.sh -e development -s authdev(1/2/3) -d`



