### PR TITLE
AUT-5339: Create orch stub ecr repo

### DIFF
--- a/orch-stub-repository/template.yaml
+++ b/orch-stub-repository/template.yaml
@@ -1,0 +1,95 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform:
+  - AWS::Serverless-2016-10-31
+  - AWS::LanguageExtensions
+
+Resources:
+  OrchStubRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: build-orch-stub-repository
+      EmptyOnDelete: true
+      ImageTagMutability: MUTABLE
+      ImageScanningConfiguration:
+        ScanOnPush: true
+      RepositoryPolicyText:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowPushFromGitHubRole
+            Effect: Allow
+            Principal:
+              AWS: !GetAtt OrchStubECRPushRole.Arn
+            Action:
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:BatchGetImage"
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:PutImage"
+              - "ecr:InitiateLayerUpload"
+              - "ecr:UploadLayerPart"
+              - "ecr:CompleteLayerUpload"
+          - Sid: AllowPullFromFrontendRole
+            Effect: Allow
+            Principal:
+              AWS: !GetAtt OrchStubECRPullRole.Arn
+            Action:
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:BatchGetImage"
+              - "ecr:BatchCheckLayerAvailability"
+      LifecyclePolicy:
+        LifecyclePolicyText: '{"rules":[{"rulePriority":1,"description":"Keep last 5 images","selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":5},"action":{"type":"expire"}}]}'
+
+  OrchStubECRPushRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: "sts:AssumeRoleWithWebIdentity"
+            Principal:
+              Federated: !ImportValue GitHubIdentityProviderArn
+            Condition:
+              StringEqualsIgnoreCase:
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+              StringLike:
+                "token.actions.githubusercontent.com:sub": "repo:govuk-one-login/authentication-stubs:*"
+      Policies:
+        - PolicyName: ECRPush
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ecr:GetAuthorizationToken"
+                Resource: "*"
+
+  OrchStubECRPullRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: "sts:AssumeRoleWithWebIdentity"
+            Principal:
+              Federated: !ImportValue GitHubIdentityProviderArn
+            Condition:
+              StringEqualsIgnoreCase:
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+              StringLike:
+                "token.actions.githubusercontent.com:sub": "repo:govuk-one-login/authentication-frontend:*"
+      Policies:
+        - PolicyName: ECRPull
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ecr:GetAuthorizationToken"
+                Resource: "*"
+
+Outputs:
+  OrchStubECRPushRoleArn:
+    Value: !GetAtt OrchStubECRPushRole.Arn
+  OrchStubECRPullRoleArn:
+    Value: !GetAtt OrchStubECRPullRole.Arn

--- a/provision-build.sh
+++ b/provision-build.sh
@@ -121,6 +121,8 @@ function provision_base_stacks {
   ./provisioner.sh "${AWS_ACCOUNT}" acceptance-tests-image-repository test-image-repository v1.2.0
 
   TEMPLATE_URL=file://deployment-configs/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" deployment-configs deployment-configs LATEST
+
+  TEMPLATE_URL=file://orch-stub-repository/template.yaml ./provisioner.sh "${AWS_ACCOUNT}" orch-stub-repository orch-stub-repository LATEST
 }
 
 # -------------------


### PR DESCRIPTION
## What

- Creates ECR repo to store orch stub built images
- These will be pulled by the frontend GHA for playwright tests
- Also creates roles to be assumed in stub and FE GHA workflows to push and pull images respectively
- This all only exists in build

## How to review

1. Code Review

