### PR TITLE
BAU: change name to am-api

### DIFF
--- a/configuration/di-authentication-development/account-management-pipeline/parameters.json
+++ b/configuration/di-authentication-development/account-management-pipeline/parameters.json
@@ -1,7 +1,7 @@
 [
   {
     "ParameterKey": "SAMStackName",
-    "ParameterValue": "dev-am-api"
+    "ParameterValue": "am-api"
   },
   {
     "ParameterKey": "Environment",


### PR DESCRIPTION
## What

am-api is the canonical name for the stack. When dev-am-api was being deployed it would get stuck in the REVIEW_IN_PROGRESS state due to trying to create resources already existing in the am-api stack.

This change resolves this by deploying account management changes to the canonical stack name

## How to review


1. Code Review
