### PR TITLE
AUT-5432: Add DynamoDB to dev frontend pipeline allowed services

### DIFF
--- a/configuration/di-authentication-development/authdev1-frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/authdev1-frontend-pipeline/parameters.json
@@ -40,6 +40,10 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "AllowedServiceThree",
+    "ParameterValue": "DynamoDB"
+  },
+  {
     "ParameterKey": "SlackNotificationType",
     "ParameterValue": "Failures"
   },

--- a/configuration/di-authentication-development/authdev2-frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/authdev2-frontend-pipeline/parameters.json
@@ -40,6 +40,10 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "AllowedServiceThree",
+    "ParameterValue": "DynamoDB"
+  },
+  {
     "ParameterKey": "SlackNotificationType",
     "ParameterValue": "Failures"
   },

--- a/configuration/di-authentication-development/authdev3-frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/authdev3-frontend-pipeline/parameters.json
@@ -40,6 +40,10 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "AllowedServiceThree",
+    "ParameterValue": "DynamoDB"
+  },
+  {
     "ParameterKey": "SlackNotificationType",
     "ParameterValue": "Failures"
   },

--- a/configuration/di-authentication-development/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/frontend-pipeline/parameters.json
@@ -36,6 +36,10 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "AllowedServiceThree",
+    "ParameterValue": "DynamoDB"
+  },
+  {
     "ParameterKey": "ECSCanaryDeployment",
     "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
   },


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Add DynamoDB to dev frontend pipeline allowed services.

Should hopefully fix any permissions boundary issues ready for the frontend session store to be migrated to DynamoDB.

Subsequent PRs will add this for higher environments.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review