### PR TITLE
AUT-5432: Add DynamoDB to higher envs frontend pipelines allowed services

### DIFF
--- a/configuration/di-authentication-build/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-build/frontend-pipeline/parameters.json
@@ -40,6 +40,10 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "AllowedServiceThree",
+    "ParameterValue": "DynamoDB"
+  },
+  {
     "ParameterKey": "SlackNotificationType",
     "ParameterValue": "Failures"
   },

--- a/configuration/di-authentication-integration/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-integration/frontend-pipeline/parameters.json
@@ -28,6 +28,10 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "AllowedServiceThree",
+    "ParameterValue": "DynamoDB"
+  },
+  {
     "ParameterKey": "IncludePromotion",
     "ParameterValue": "No"
   },

--- a/configuration/di-authentication-production/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-production/frontend-pipeline/parameters.json
@@ -28,6 +28,10 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "AllowedServiceThree",
+    "ParameterValue": "DynamoDB"
+  },
+  {
     "ParameterKey": "IncludePromotion",
     "ParameterValue": "No"
   },

--- a/configuration/di-authentication-staging/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-staging/frontend-pipeline/parameters.json
@@ -32,6 +32,10 @@
     "ParameterValue": "ECR & ECS"
   },
   {
+    "ParameterKey": "AllowedServiceThree",
+    "ParameterValue": "DynamoDB"
+  },
+  {
     "ParameterKey": "SlackNotificationType",
     "ParameterValue": "Failures"
   },


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Add DynamoDB to frontend pipeline allowed services for build, staging, integration, and production.

Should update the permissions boundary ready for the frontend session store to be migrated to DynamoDB.

Dev envs PR (merged): https://github.com/govuk-one-login/authentication-infrastructure/pull/150

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review