### PR TITLE
BAU: Constrain fast-xml-builder to >=1.1.7 to fix CVE-2026-44665 and CVE-2026-44664

### DIFF
--- a/alerts/src/package-lock.json
+++ b/alerts/src/package-lock.json
@@ -1287,9 +1287,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -1298,7 +1298,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -1354,6 +1355,21 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     }
   }
 }

--- a/alerts/src/package.json
+++ b/alerts/src/package.json
@@ -11,6 +11,7 @@
     "build": "mkdir -p ../dist && zip -r ../dist/alerts.zip ."
   },
   "overrides": {
-    "fast-xml-parser": ">=5.7.1"
+    "fast-xml-parser": ">=5.7.1",
+    "fast-xml-builder": ">=1.1.7"
   }
 }


### PR DESCRIPTION
## What

- CVE-2026-44665: fast-xml-builder allows attribute values with unwanted quotes to bypass malicious or unwanted attributes. Fixed in 1.1.7.
- CVE-2026-44664: fast-xml-builder Comment Value regex can be bypassed. Fixed in 1.1.6.
- Both CVEs are resolved by constraining fast-xml-builder to >=1.1.7 in alerts/src. This is a transitive dependency brought in via the AWS SDK.

## How to review

1. Code Review