### PR TITLE
BAU:Sort run history  by actual execution time rather than by UUID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ authentication-frontend
 !.vscode/*.code-snippets
 
 cf-template.*
+**/.DS_Store

--- a/configuration/di-authentication-development/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/frontend-pipeline/parameters.json
@@ -41,7 +41,7 @@
   },
   {
     "ParameterKey": "ECSCanaryDeployment",
-    "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
+    "ParameterValue": "None"
   },
   {
     "ParameterKey": "IncludePromotion",

--- a/pipeline-visualiser/lib/pipeline_history_store.rb
+++ b/pipeline-visualiser/lib/pipeline_history_store.rb
@@ -40,7 +40,9 @@ class PipelineHistoryStore
       scan_index_forward: false,
       limit: limit
     )
-    result.items
+
+    # Sort by started_at timestamp in descending order (latest first)
+    result.items.sort_by { |item| item["started_at"] }.reverse
   rescue StandardError => e
     puts "Error fetching pipeline history for #{pipeline_name}: #{e.message}"
     []


### PR DESCRIPTION
## What

1) Sort the pipeline-visualiser run history  by actual execution time rather than by UUID
2) Disabling ECS Canary  in Dev as Canary Stackset is failing due to code sign issue

## How to review

1. Code Review
