### PR TITLE
Revert "AUT-5441: Switch frontend pipeline deploy strategy to AllAtOnce for Redis-DynamoDB cutover"

### DIFF
--- a/configuration/di-authentication-build/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-build/frontend-pipeline/parameters.json
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ECSCanaryDeployment",
-    "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
+    "ParameterValue": "CodeDeployDefault.ECSCanary10Percent5Minutes"
   },
   {
     "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",

--- a/configuration/di-authentication-production/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-production/frontend-pipeline/parameters.json
@@ -45,7 +45,7 @@
   },
   {
     "ParameterKey": "ECSCanaryDeployment",
-    "ParameterValue": "CodeDeployDefault.ECSAllAtOnce"
+    "ParameterValue": "CodeDeployDefault.ECSCanary10Percent5Minutes"
   },
   {
     "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",


### PR DESCRIPTION
NOTE: DEPENDS ON MERGE OF https://github.com/govuk-one-login/authentication-frontend/pull/3421

Reverts govuk-one-login/authentication-infrastructure#154 following completion of the frontend Redis migration

Stack updates will need to be applied in the relevant accounts