### PR TITLE
AUT-5474: Turn on params required for account management api tests

### DIFF
--- a/configuration/di-authentication-build/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-build/frontend-pipeline/parameters.json
@@ -66,5 +66,13 @@
   {
     "ParameterKey": "StoreTestReportInS3Bucket",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "RunTestContainerInVPC",
+    "ParameterValue": "True"
+  },
+  {
+    "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",
+    "ParameterValue": "Yes"
   }
 ]

--- a/configuration/di-authentication-development/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-development/frontend-pipeline/parameters.json
@@ -54,5 +54,13 @@
   {
     "ParameterKey": "StoreTestReportInS3Bucket",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "RunTestContainerInVPC",
+    "ParameterValue": "True"
+  },
+  {
+    "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",
+    "ParameterValue": "Yes"
   }
 ]

--- a/configuration/di-authentication-staging/frontend-pipeline/parameters.json
+++ b/configuration/di-authentication-staging/frontend-pipeline/parameters.json
@@ -58,5 +58,13 @@
   {
     "ParameterKey": "StoreTestReportInS3Bucket",
     "ParameterValue": "Yes"
+  },
+  {
+    "ParameterKey": "RunTestContainerInVPC",
+    "ParameterValue": "True"
+  },
+  {
+    "ParameterKey": "TestContainerAllowCrossAccountAssumeRole",
+    "ParameterValue": "Yes"
   }
 ]


### PR DESCRIPTION
## What

We want to run the mfa-reset-migrated.feature file in the frontend pipeline tests. These were failing on previous attempts due to these tests calling the account management API, which, because it is a private API and the test container was running outside of the VPC, there were network failures.

The addition of these parameters allow:
- The test container to hit the private API as it is running in the same VPC
- The test container access to the old data store accounts for test setup

As mfa-reset-migrated.feature tests are essentially testing UI functionality, using the account management API for test set up, we intend to make these tests interact with the database directly for test set up in the future. This would not effect coverage as the account management API itself is covered by rest assured API tests. After these changes in the future we can move the test container back out of the VPC.

## How to review

1. Code Review

