### PR TITLE
BAU: Add SNS topic for #di-authentication-notifications

### DIFF
--- a/alerts/template.yaml
+++ b/alerts/template.yaml
@@ -53,6 +53,9 @@ Conditions:
   IsDevEnvironment: !Equals
     - !Ref Environment
     - "dev"
+  IsProduction: !Equals
+    - !Ref Environment
+    - "production"
 
 Mappings:
   EnvironmentConfiguration:
@@ -354,6 +357,57 @@ Resources:
       Tags:
         Application: "Authentication"
         Source: govuk-one-login/authentication-infrastructure/alerts/template.yaml
+
+  SlackAuthNotificationTopic:
+    Type: AWS::SNS::Topic
+    Condition: IsProduction
+    Properties:
+      TopicName: !Sub "${Environment}-slack-auth-notifications"
+      Tags:
+        - Key: Name
+          Value: !Sub "${Environment}-slack-auth-notifications"
+        - Key: Service
+          Value: "Authentication"
+        - Key: Source
+          Value: "govuk-one-login/authentication-infrastructure/alerts/template.yaml"
+
+  SlackAuthNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Condition: IsProduction
+    Properties:
+      Topics:
+        - !Ref SlackAuthNotificationTopic
+      PolicyDocument:
+        Statement:
+          - Action: "sns:Publish"
+            Effect: Allow
+            Resource: !Ref SlackAuthNotificationTopic
+            Principal:
+              Service:
+                - cloudwatch.amazonaws.com
+
+  SlackAuthNotificationTopicSSM:
+    Type: AWS::SSM::Parameter
+    Condition: IsProduction
+    Properties:
+      Description: "The ARN of the SNS topic for #di-authentication-notifications alerts"
+      Name: !Sub "/deploy/${Environment}/slack_auth_notification_topic_arn"
+      Type: String
+      Value: !Ref SlackAuthNotificationTopic
+      Tags:
+        Application: "Authentication"
+        Source: govuk-one-login/authentication-infrastructure/alerts/template.yaml
+
+  AuthNotificationsChatbotConfiguration:
+    Type: AWS::Chatbot::SlackChannelConfiguration
+    Condition: IsProduction
+    Properties:
+      ConfigurationName: !Sub "${AWS::StackName}-auth-notifications"
+      IamRoleArn: !GetAtt ChatbotRole.Arn
+      SlackChannelId: "C06HMLMEQ1W"
+      SlackWorkspaceId: !Ref SlackWorkspaceId
+      SnsTopicArns:
+        - !Ref SlackAuthNotificationTopic
 
 # Below SNS topic are for Authdevs only created in Dev AWS account
 # IF subscription if required for testing in authdev please created againt 'dev-alerts' Lambda


### PR DESCRIPTION
## What

- Adds a production-only SNS topic (`${Environment}-slack-auth-notifications`) for routing CloudWatch alarms to `#di-authentication-notifications`
- Includes a topic policy allowing CloudWatch to publish
- Exposes the topic ARN via SSM at `/deploy/${Environment}/slack_auth_notification_topic_arn`
- Adds an AWS Chatbot configuration subscribed to the topic that posts to `#di-authentication-notifications` (channel ID `C06HMLMEQ1W`), reusing the existing `ChatbotRole`

This lives alongside the existing `SlackAlertNotificationTopic` (which routes to `#di-2nd-line`) and is a prerequisite for the enhanced auth code block alarm which needs to notify `#di-authentication-notifications` instead.

## How to review

1. Code Review - check `alerts/template.yaml` for the new `IsProduction` condition and four new resources