### PR TITLE
BAU: Add production SNS topic for #di-authentication-notifications

### DIFF
--- a/alerts/template.yaml
+++ b/alerts/template.yaml
@@ -53,6 +53,9 @@ Conditions:
   IsDevEnvironment: !Equals
     - !Ref Environment
     - "dev"
+  IsProduction: !Equals
+    - !Ref Environment
+    - "production"
 
 Mappings:
   EnvironmentConfiguration:
@@ -354,6 +357,57 @@ Resources:
       Tags:
         Application: "Authentication"
         Source: govuk-one-login/authentication-infrastructure/alerts/template.yaml
+
+  ProdAuthNotificationsChannelTopic:
+    Type: AWS::SNS::Topic
+    Condition: IsProduction
+    Properties:
+      TopicName: "production-auth-notifications-channel"
+      Tags:
+        - Key: Name
+          Value: "production-auth-notifications-channel"
+        - Key: Service
+          Value: "Authentication"
+        - Key: Source
+          Value: "govuk-one-login/authentication-infrastructure/alerts/template.yaml"
+
+  ProdAuthNotificationsChannelTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Condition: IsProduction
+    Properties:
+      Topics:
+        - !Ref ProdAuthNotificationsChannelTopic
+      PolicyDocument:
+        Statement:
+          - Action: "sns:Publish"
+            Effect: Allow
+            Resource: !Ref ProdAuthNotificationsChannelTopic
+            Principal:
+              Service:
+                - cloudwatch.amazonaws.com
+
+  ProdAuthNotificationsChannelTopicSSM:
+    Type: AWS::SSM::Parameter
+    Condition: IsProduction
+    Properties:
+      Description: "The ARN of the production SNS topic for #di-authentication-notifications (separate from the #di-2nd-line alerts topic)"
+      Name: "/deploy/production/auth_notifications_channel_topic_arn"
+      Type: String
+      Value: !Ref ProdAuthNotificationsChannelTopic
+      Tags:
+        Application: "Authentication"
+        Source: govuk-one-login/authentication-infrastructure/alerts/template.yaml
+
+  ProdAuthNotificationsChannelChatbot:
+    Type: AWS::Chatbot::SlackChannelConfiguration
+    Condition: IsProduction
+    Properties:
+      ConfigurationName: !Sub "${AWS::StackName}-auth-notifications-channel"
+      IamRoleArn: !GetAtt ChatbotRole.Arn
+      SlackChannelId: "C06HMLMEQ1W"
+      SlackWorkspaceId: !Ref SlackWorkspaceId
+      SnsTopicArns:
+        - !Ref ProdAuthNotificationsChannelTopic
 
 # Below SNS topic are for Authdevs only created in Dev AWS account
 # IF subscription if required for testing in authdev please created againt 'dev-alerts' Lambda


### PR DESCRIPTION
## What

- Add ProdAuthNotificationsChannelTopic for routing CloudWatch
  alarms to #di-authentication-notifications, separate from the
  existing #di-2nd-line alerts topic
- The existing topic is in all environments, subscribed to by:
  - AWS Chatbot in integration hooked to
    #di-authentication-notifications
  - Alerts lambda in authentication-smoke-tests hooked to
    #di-2nd-line
- We want a production alert that does _not_ go to #di-2nd-line
- Add ProdAuthNotificationsChannelChatbot that subscribes to
  the topic and posts to #di-authentication-notifications
  (channel C06HMLMEQ1W, used in authentication-check-experian
  by build, staging and integration; see [here](https://github.com/govuk-one-login/authentication-check-experian/blob/75fc6b18fa29dc38acd56ec474670168ab83d00e/deploy/application/phone-check/template.yaml#L119)), reusing the existing
  ChatbotRole
- Added SSM parameter with the topic ARN for reference in
  the authentication-api alarm

## How to review

1. Code Review
2. With the related PR, test that the CloudWatch alarm triggers a message to be put to the #di-authentication-notifications slack channel. This can be done by bumping the count on the enhanced auth code protection metric to >30

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/8641

